### PR TITLE
docs: recommend pre-compiled binaries over building from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION=$(shell awk -F'"' '/"version":/ {print $$4}' version.json)
 GOFLAGS=-ldflags="-X github.com/storacha/piri/pkg/build.version=$(VERSION)"
 TAGS?=
 
-.PHONY: all build piri install test clean calibnet mockgen
+.PHONY: all build piri install test clean calibnet mockgen check-docs-links
 
 all: build
 
@@ -36,3 +36,7 @@ mockgen:
 # special target that sets the calibnet tag and invokes build
 calibnet: TAGS=-tags calibnet
 calibnet: build
+
+# Check for broken links in documentation
+check-docs-links:
+	@./scripts/check-docs-links.sh

--- a/README.md
+++ b/README.md
@@ -4,83 +4,33 @@
   <p>A storage node that runs on the Storacha network.</p>
 </div>
 
-## Usage
+## What is Piri?
 
-### Getting Started
+What's Piri? It's the _**P**rovable **I**nformation **R**etention **I**nterface_ - a Go-based storage node that's part of the Storacha network backbone. It works alongside other services like the [indexing service](https://github.com/storacha/indexing-service) and [upload service](https://github.com/storacha/upload-service) to enable decentralized storage with cryptographic proofs.
 
-Install [Go](https://go.dev) v1.23.3 or higher.
+## Documentation
 
-Next, generate a private key for your piri node. This can be done on any computer, not necessarily the deployment target.
+Get started with Piri by exploring our comprehensive documentation:
 
-Clone the repo and `cd` into the repo directory:
+- **[📚 Documentation Home](./docs/)** - Start here for an overview
+- **[🚀 Getting Started](./docs/getting-started.md)** - Quick start guide for different use cases
+- **[🏗️ Architecture](./docs/architecture.md)** - Understand how Piri works
+- **[📖 Full Documentation](./docs/README.md)** - Complete documentation index
 
-```sh
-git clone https://github.com/storacha/piri.git
-cd piri
-```
+### Quick Links
 
-Build and install the CLI tool:
-
-```sh
-make install
-```
-
-Generate a new identity:
-
-```sh
-piri identity gen
-```
-
-Make a note of your node identity. The string beginning `Mg` is your private key. Do not share this with anyone!
-
-Next, obtain a delegation allowing your node to publish claims to the Storacha Indexer node(s). Contact the engineers in `#node-providers` on the Storacha Discord - give them your _public_ key (the string beginning with `did:key:`).
-
-### System Requriements
-
-TODO
-
-### Deployment
-
-#### Environment Variables
-
-The environment variables required to start a node are:
-
-```sh
-PIRI_PRIVATE_KEY=                # string beginning Mg...
-PIRI_PUBLIC_URL=                 # URL the node will be publically accessible at
-PIRI_PORT=                       # local port to bind the server to
-PIRI_INDEXING_SERVICE_PROOF=     # delegation(s) from the Storacha Indexing node(s)
-```
-
-#### Deployment to a VM/Bare Metal
-
-Clone the repo and build the binary as per the [getting started](#getting-started) section. Set environment variables as above. The following command will start the Storage Node daemon:
-
-```sh
-piri start
-```
-
-#### Deployment to DigitalOcean
-
-The [Dockerfile](./Dockerfile) allows a Storage Node to be deployed to DigitalOcean Apps platform. You'll need to setup a "Spaces Object Storage" bucket to persist data. You must configure the following additional environment variables:
-
-```sh
-PIRI_S3_ENDPOINT=
-PIRI_S3_REGION=
-PIRI_S3_BUCKET=
-PIRI_S3_ACCESS_KEY=
-PIRI_S3_SECRET_KEY=
-```
-
-#### Deployment to AWS
-
-The Terraform scripts in `/deploy` allow a Storage Node to be deployed to AWS. See [deploy/README.md](./deploy/README.md) for instructions.
+- **New to Piri?** Start with the [Getting Started Guide](./docs/getting-started.md)
+- **Ready to run a storage provider?** See the [Full Stack Setup Guide](./docs/integrations/full-stack-setup.md)
+- **Want to understand the system?** Read the [Architecture Overview](./docs/architecture.md)
 
 ## Contributing
 
 All welcome! Storacha is open-source. Please feel empowered to open a PR or an issue.
 
+### Reporting Issues
+
+Found a bug or have a feature request? Please [open an issue](https://github.com/storacha/piri/issues) on our GitHub repository.
+
 ## License
 
 Dual-licensed under [Apache 2.0 OR MIT](LICENSE.md)
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ Advanced deployment scenarios:
 ```bash
 piri id gen -t=pem
 ```
-See the [PEM File Generation](./common/key-generation) guide for details.
+See the [PEM File Generation](./common/key-generation.md) guide for details.
 
 ### Check Server Health
 ```bash
@@ -83,7 +83,7 @@ piri proofset create --key-file=service.pem --pdp-server-url=https://pdp.your-do
 Each guide includes a troubleshooting section. Common issues:
 
 - **Connection errors**: Check [TLS setup](./common/tls-termination.md) and firewall rules
-- **Authentication failures**: Verify [PEM file](./common/key-generation) and delegations
+- **Authentication failures**: Verify [PEM file](./common/key-generation.md) and delegations
 - **Installation issues**: Review [prerequisites](./common/prerequisites.md) and [installation](./common/piri-installation.md)
 
 ### Support Channels
@@ -101,7 +101,7 @@ Each guide includes a troubleshooting section. Common issues:
 ### Common Procedures
 - [Prerequisites](./common/prerequisites.md)
 - [Piri Installation](./common/piri-installation.md)
-- [Keypair Generation](./common/key-generation)
+- [Keypair Generation](./common/key-generation.md)
 - [TLS Termination](./common/tls-termination.md)
 
 ### Setup Guides
@@ -112,9 +112,6 @@ Each guide includes a troubleshooting section. Common issues:
 - [Piri with Curio](./integrations/piri-with-curio.md)
 - [Full Stack Setup](./integrations/full-stack-setup.md)
 
-### Legacy Guides
-- [Original PDP Server Guide](./PIRI-PDP-SERVER-GUIDE.md) (deprecated)
-- [Original UCAN Server Guide](./PIRI-UCAN-SERVER-GUIDE.md) (deprecated)
 
 ## 🔄 Version Information
 
@@ -125,7 +122,7 @@ This documentation is for Piri version 1.x. For the latest updates:
 piri version
 
 # Update Piri
-cd piri && git pull && make calibnet
+cd piri && git pull && make
 ```
 
 ## 📝 Contributing

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,19 +49,38 @@ The UCAN server is responsible for:
 
 ### Upload Flow
 
-1. **Upload**: Storacha sends data with UCAN auth token
-2. **UCAN Validation**: Server validates the authorization
-3. **Data Forward**: UCAN server forwards data to PDP backend
-4. **Storage**: PDP server stores the piece
-5. **Proof Generation**: PDP server generates possession proofs
-6. **Contract Submission**: Proofs submitted to Filecoin smart contract
+```mermaid
+sequenceDiagram
+    participant Client
+    participant UploadService as Upload Service
+    participant UCANServer as UCAN Server
+    participant PDPServer as PDP Server
+    participant IndexingService as Indexing Service
+    participant Filecoin as Filecoin Network
+
+    Client->>UploadService: Upload data
+    UploadService->>UCANServer: Request blob/allocate
+    UCANServer->>PDPServer: Request to allocate blob
+    PDPServer-->>UCANServer: Return URL with UUID
+    UCANServer-->>UploadService: Provide URL
+    UploadService-->>Client: Provide URL
+    
+    Client->>PDPServer: PUT data to URL
+    
+    Client->>UploadService: Send blob/accept
+    UploadService->>UCANServer: Forward blob/accept
+    UCANServer->>PDPServer: Tell to accept blob
+    UCANServer->>IndexingService: Write LocationCommitment
+    
+    loop Every proving period
+        PDPServer->>Filecoin: Submit proof
+        Note over PDPServer,Filecoin: New blobs may be added via this process
+    end
+```
 
 ### Retrieval Flow
 
-1. **Request**: Request for specific piece CID
-2. **Auth Check**: UCAN server validates permissions
-3. **PDP Query**: Request forwarded to PDP server
-4. **Data Return**: Piece data returned through UCAN to requester
+TODO: Document the retrieval architecture with Mermaid diagram
 
 ## Configuration Relationships
 

--- a/docs/common/piri-installation.md
+++ b/docs/common/piri-installation.md
@@ -4,7 +4,25 @@ This guide covers the installation of the Piri binary, which is used for both PD
 
 ## Installation Methods
 
-### Method 1: Build from Source (Recommended)
+### Method 1: Download Pre-compiled Binary (Recommended)
+
+Downloading the pre-compiled binary is the quickest way to get started with Piri.
+
+Download the latest release from [v0.0.6](https://github.com/storacha/piri/releases/tag/v0.0.6):
+
+```bash
+# For Linux AMD64
+wget https://github.com/storacha/piri/releases/download/v0.0.6/piri_0.0.6_linux_amd64.tar.gz
+tar -xzf piri_0.0.6_linux_amd64.tar.gz
+sudo mv piri /usr/local/bin/piri
+
+# For Linux ARM64
+wget https://github.com/storacha/piri/releases/download/v0.0.6/piri_0.0.6_linux_arm64.tar.gz
+tar -xzf piri_0.0.6_linux_arm64.tar.gz
+sudo mv piri /usr/local/bin/piri
+```
+
+### Method 2: Build from Source (Alternative)
 
 Building from source ensures you have the latest version with network-specific optimizations.
 
@@ -15,41 +33,14 @@ Building from source ensures you have the latest version with network-specific o
 git clone https://github.com/storacha/piri
 cd piri
 
-# Build for your target network
-make calibnet    # For Calibration testnet
-# OR
-make mainnet     # For Mainnet (when available)
+# Checkout the specific version
+git checkout v0.0.6
+
+# Build
+make
 
 # Install binary
 sudo cp piri /usr/local/bin/piri
-
-# Verify installation
-piri version
-```
-
-#### Build Targets
-
-- `make calibnet`: Builds with Calibration network parameters
-- `make mainnet`: Builds with Mainnet parameters
-
-### Method 2: Download Pre-built Binary
-
-Check the [releases page](https://github.com/storacha/piri/releases) for pre-built binaries:
-
-```bash
-# Example for Linux amd64
-wget https://github.com/storacha/piri/releases/download/vX.Y.Z/piri-linux-amd64
-chmod +x piri-linux-amd64
-sudo mv piri-linux-amd64 /usr/local/bin/piri
-```
-
-### Method 3: Using Go Install
-
-For Go developers:
-
-```bash
-go install github.com/storacha/piri/cmd/storage@latest
-mv ~/go/bin/storage /usr/local/bin/piri
 ```
 
 ## Post-Installation Setup
@@ -57,9 +48,6 @@ mv ~/go/bin/storage /usr/local/bin/piri
 ### 1. Verify Installation
 
 ```bash
-# Check version
-piri version
-
 # View available commands
 piri --help
 ```
@@ -169,59 +157,37 @@ sudo systemctl status piri-pdp
 sudo systemctl status piri-ucan
 ```
 
-## Docker Installation (Alternative)
-
-For containerized deployments:
-
-```dockerfile
-FROM golang:1.24-alpine AS builder
-RUN apk add --no-cache git make
-WORKDIR /app
-COPY . .
-RUN make calibnet
-
-FROM alpine:latest
-RUN apk add --no-cache ca-certificates
-COPY --from=builder /app/piri /usr/local/bin/
-ENTRYPOINT ["piri"]
-```
-
-Build and run:
-```bash
-docker build -t piri:latest .
-docker run -p 3000:3000 piri:latest start --help
-```
-
 ## Updating Piri
+
+### Binary Updates (Recommended)
+
+```bash
+# Download new version (replace with latest version as needed)
+wget https://github.com/storacha/piri/releases/download/v0.0.6/piri_0.0.6_linux_amd64.tar.gz
+tar -xzf piri_0.0.6_linux_amd64.tar.gz
+
+# Replace binary
+sudo systemctl stop piri-pdp piri-ucan
+sudo mv piri /usr/local/bin/piri
+sudo systemctl start piri-pdp piri-ucan
+```
 
 ### From Source
 
 ```bash
 cd piri
-git pull origin main
-make calibnet
+git fetch --tags
+git checkout v0.0.6  # or latest version
+make
 sudo systemctl stop piri-pdp piri-ucan
 sudo cp piri /usr/local/bin/
-sudo systemctl start piri-pdp piri-ucan
-```
-
-### Binary Updates
-
-```bash
-# Download new version
-wget https://github.com/storacha/piri/releases/download/vX.Y.Z/piri-linux-amd64
-
-# Replace binary
-sudo systemctl stop piri-pdp piri-ucan
-sudo mv piri-linux-amd64 /usr/local/bin/piri
-sudo chmod +x /usr/local/bin/piri
 sudo systemctl start piri-pdp piri-ucan
 ```
 
 ## Next Steps
 
 After installation:
-1. [Generate PEM file](./key-generation) for identity
+1. [Generate PEM file](./key-generation.md) for identity
 2. [Configure TLS](./tls-termination.md) for production
 3. Follow specific guides:
    - [PDP Server Setup](../guides/pdp-server-piri.md)

--- a/docs/common/prerequisites.md
+++ b/docs/common/prerequisites.md
@@ -19,8 +19,8 @@ Specific services may have additional requirements noted in their respective gui
 **Recommended (Production)**
 - 4+ CPU cores
 - 8+ GB RAM
-- 1+ TB storage (depends on data volume)
-- 1+ Gbps Symmetric network connection (depends on data volume)
+- 1+ TB storage
+- 1+ Gbps Symmetric network connection
 
 ## Software Dependencies
 
@@ -28,19 +28,23 @@ Specific services may have additional requirements noted in their respective gui
 
 Install the following packages:
 
+#### Debian/Ubuntu
 ```bash
-# Debian/Ubuntu
 apt update
 apt install -y make git jq curl wget
+````
 
-# macOS (using Homebrew)
+#### macOS (using Homebrew)
+```
 brew install make git jq curl wget
+```
 
-# RHEL/CentOS
+#### RHEL/CentOS
+```
 yum install -y make git jq curl wget
 ```
 
-### Go Language
+### Go Language (Development)
 
 Building Piri from source requires Go 1.24 or later:
 
@@ -63,11 +67,7 @@ go version
 For production deployments, install a reverse proxy:
 
 ```bash
-# Option 1: Nginx (recommended)
 apt install -y nginx certbot python3-certbot-nginx
-
-# Option 2: Caddy
-# See TLS termination guide for installation
 ```
 
 ## Network Requirements
@@ -96,6 +96,7 @@ ufw allow 3001/tcp  # PDP server
 
 1. **Lotus Node** (Calibration Network)
    - Synced Lotus node with RPC access
+   - Latest Calibration Network [Snapshot](https://forest-archive.chainsafe.dev/latest/calibnet/)
    - WebSocket endpoint (e.g., `wss://lotus.example.com/rpc/v1`)
    - Basic understanding of Filecoin primitives
 
@@ -146,6 +147,6 @@ nc -zv YOUR_DOMAIN 443
 
 After meeting prerequisites:
 1. [Install Piri](./piri-installation.md)
-2. [Generate PEM file](./key-generation)
+2. [Generate PEM file](./key-generation.md)
 3. [Configure TLS termination](./tls-termination.md)
 4. Follow service-specific guides

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,11 +29,31 @@ Before starting, ensure you have:
 
 ## Quick Start
 
+### Download Pre-compiled Binary (Recommended)
+
+```bash
+# For Linux AMD64
+wget https://github.com/storacha/piri/releases/download/v0.0.6/piri_0.0.6_linux_amd64.tar.gz
+tar -xzf piri_0.0.6_linux_amd64.tar.gz
+sudo mv piri /usr/local/bin/
+
+# For Linux ARM64
+wget https://github.com/storacha/piri/releases/download/v0.0.6/piri_0.0.6_linux_arm64.tar.gz
+tar -xzf piri_0.0.6_linux_arm64.tar.gz
+sudo mv piri /usr/local/bin/
+
+# Generate identity
+piri id gen -t=pem > service.pem
+```
+
+### Build from Source (Alternative)
+
 ```bash
 # Clone and build
 git clone https://github.com/storacha/piri
 cd piri
-make calibnet
+git checkout v0.0.6
+make
 
 # Generate identity
 piri id gen -t=pem > service.pem

--- a/docs/guides/pdp-server-piri.md
+++ b/docs/guides/pdp-server-piri.md
@@ -109,7 +109,19 @@ Monitor server activity:
 journalctl -u piri-pdp -f
 ```
 
-## Step 5: Integration
+## Step 5: Monitor Your ProofSets
+
+You can inspect your ProofSets and verify proof submissions using the PDP explorer:
+
+🔍 **[PDP Explorer (Calibration Network)](https://pdpscan.vercel.app/calibration)**
+
+This explorer allows you to:
+- View all ProofSets associated with your address
+- Check proof submission status
+- Monitor proving periods
+- Verify successful proof validations
+
+## Step 6: Integration
 
 Your PDP server is now ready to:
 1. Accept pieces from UCAN servers

--- a/docs/guides/ucan-server.md
+++ b/docs/guides/ucan-server.md
@@ -17,7 +17,7 @@ Before starting, ensure you have:
 
 1. ✅ [Met system prerequisites](../common/prerequisites.md)
 2. ✅ [Installed Piri](../common/piri-installation.md)
-3. ✅ [Generated a PEM file](../common/key-generation) with Ed25519 key
+3. ✅ [Generated a PEM file](../common/key-generation.md) with Ed25519 key
 4. ✅ Access to a PDP server (Piri or Curio) at an HTTPS endpoint
 5. ✅ [Configured TLS termination](../common/tls-termination.md) for your domain
 
@@ -76,7 +76,7 @@ Check the status of your proof set creation:
 ```bash
 piri proofset status \
   --key-file=service.pem \
-  --curio-url=https://YOUR_PDP_DOMAIN \
+  --pdp-server-url=https://YOUR_PDP_DOMAIN \
   --ref-url=/pdp/proof-set/created/HASH_FROM_CREATE_OUTPUT
 ```
 
@@ -140,7 +140,7 @@ source .env
 ```bash
 piri start \
   --key-file=service.pem \
-  --curio-url=https://YOUR_PDP_DOMAIN \
+  --pdp-server-url=https://YOUR_PDP_DOMAIN \
   --port=3000
 ```
 
@@ -149,7 +149,7 @@ piri start \
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--key-file` | Path to your PEM file | Required |
-| `--curio-url` | HTTPS URL of your PDP backend | Required |
+| `--pdp-server-url` | HTTPS URL of your PDP backend | Required |
 | `--port` | Local port to listen on | 3000 |
 
 ### Production Example
@@ -157,7 +157,7 @@ piri start \
 ```bash
 piri start \
   --key-file=/etc/piri/service.pem \
-  --curio-url=https://pdp.example.com \
+  --pdp-server-url=https://pdp.example.com \
   --port=3000 \
 ```
 

--- a/docs/integrations/full-stack-setup.md
+++ b/docs/integrations/full-stack-setup.md
@@ -187,7 +187,7 @@ sudo -u piri piri proofset create \
 # Monitor status
 sudo -u piri piri proofset status \
   --key-file=service.pem \
-  --curio-url=https://pdp.example.com \
+  --pdp-server-url=https://pdp.example.com \
   --ref-url=/pdp/proof-set/created/HASH_FROM_CREATE
 ```
 
@@ -265,7 +265,7 @@ WorkingDirectory=/var/lib/piri/ucan
 EnvironmentFile=/etc/piri/storacha.env
 ExecStart=/usr/local/bin/piri start \
   --key-file=/etc/piri/service.pem \
-  --curio-url=https://pdp.example.com \
+  --pdp-server-url=https://pdp.example.com \
   --port=3000 \
 Restart=on-failure
 RestartSec=10
@@ -301,6 +301,5 @@ Your full Piri stack is now operational! Consider:
 - [Architecture Overview](../architecture.md) - System design
 - [PDP Server Guide](../guides/pdp-server-piri.md) - PDP details
 - [UCAN Server Guide](../guides/ucan-server.md) - UCAN details
-- [Troubleshooting](../README.md#troubleshooting) - Common issues
 
 Congratulations on joining the Storacha network! 🎉

--- a/docs/integrations/piri-with-curio.md
+++ b/docs/integrations/piri-with-curio.md
@@ -28,7 +28,7 @@ Before starting, ensure you have:
 2. ✅ **System ready for Piri**:
    - [Prerequisites met](../common/prerequisites.md)
    - [Piri installed](../common/piri-installation.md)
-   - [Keypair PEM file generated](../common/key-generation)
+   - [Keypair PEM file generated](../common/key-generation.md)
 
 3. ✅ **Network requirements**:
    - Domain for UCAN server
@@ -74,7 +74,7 @@ Monitor creation status:
 ```bash
 piri proofset status \
   --key-file=service.pem \
-  --curio-url=https://curio.example.com \
+  --pdp-server-url=https://curio.example.com \
   --ref-url=/pdp/proof-set/created/HASH_FROM_CREATE
 ```
 
@@ -116,7 +116,7 @@ source .env
 ```bash
 piri start \
   --key-file=service.pem \
-  --curio-url=https://curio.example.com \
+  --pdp-server-url=https://curio.example.com \
   --port=3000
 ```
 
@@ -136,7 +136,7 @@ Group=piri
 EnvironmentFile=/etc/piri/storacha.env
 ExecStart=/usr/local/bin/piri start \
   --key-file=/etc/piri/service.pem \
-  --curio-url=https://curio.example.com \
+  --pdp-server-url=https://curio.example.com \
   --port=3000 \
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
- Update documentation to recommend downloading pre-compiled binaries from v0.0.6 release as the primary installation method. Building from source is now listed as an alternative option with instructions to checkout the specific version tag.

- convert upload architecture to Mermaid diagram when blob/accept is received.

- fix some consistency issues