### PR TITLE
fix: checksum in presigned requests

### DIFF
--- a/pkg/presigner/s3.go
+++ b/pkg/presigner/s3.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/piri/pkg/internal/digestutil"
 )
@@ -34,6 +35,9 @@ func (ss *S3RequestPresigner) SignUploadURL(ctx context.Context, digest multihas
 	digestInfo, err := multihash.Decode(digest)
 	if err != nil {
 		return url.URL{}, nil, fmt.Errorf("decoding digest: %w", err)
+	}
+	if digestInfo.Code != uint64(multicodec.Sha2_256) {
+		return url.URL{}, nil, fmt.Errorf("unsupported digest: %d", digestInfo.Code)
 	}
 	signedReq, err := ss.presignClient.PresignPutObject(
 		ctx,


### PR DESCRIPTION
This adds the missing checksum in presigned requests.

I had to google hard for how to do this in Go. Finally found https://github.com/aws/aws-sdk/issues/480#issuecomment-2065197264

Existing presigned URLs did not include `x-amz-checksum-sha256` in the signed headers and wasn't returning the `x-amz-checksum-sha256` as a header that the client needs to send.

AWS doesn't support `x-amz-checksum-sha256` in the query string - it is silently ignored on the backend. However, it can be a request header, and we _do_ want it to be one of the signed headers.

### Before

URL: `http://localhost:3000/data/zQmcuYW5AG3STkAqxGowojKzEfWYRssRdUEyJJAnFawLPNN?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=did%3Akey%3Az6MkrLosJPxqiQdTccuJ6csvZ5eV6RT4ZqEYhNxP7x8wGXJq%2F20250701%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20250701T104518Z&X-Amz-Expires=900&`**`X-Amz-SignedHeaders=content-length%3Bhost`**`&x-id=PutObject&X-Amz-Signature=9f95e75b2ad4f897839f170c6d443c3e087a047d08d85599aff2c35eaefa03b7`

Headers: `map[Content-Length:[138] Host:[localhost:3000]]`

### After

URL: `http://localhost:3000/data/zQmSDmuaK4Xx45TnNJt614RdkqjGuh2xCjG4MkqgtYrysat?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=did%3Akey%3Az6MkpBUCmNQPAKKjSsuqfDTUw67AZvBMEAx6XgQAKfd2D7GN%2F20250701%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20250701T102757Z&X-Amz-Expires=900&`**`X-Amz-SignedHeaders=content-length%3Bhost%3Bx-amz-checksum-sha256`**`&x-id=PutObject&X-Amz-Signature=aca15e0ffc5c88b0d83643dc7757b5f1ec8e2f144cc1eeb704242a9d4e35539b`

Headers: `map[Content-Length:[138] Host:[localhost:3000]`**`X-Amz-Checksum-Sha256:[OavSDzO6I4a65E/MoL1s44ikRLtzNKGF5UhJvMdD7iU=]]`**

---

JS implementation for reference: https://github.com/storacha/w3infra/blob/d323523789006e9cc1ce5fab72d1a1920f551898/upload-api/stores/blobs.js#L85-L108