### PR TITLE
chore: upgrade go-ucanto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.8.1
 	github.com/storacha/go-libstoracha v0.2.0
-	github.com/storacha/go-ucanto v0.4.2
+	github.com/storacha/go-ucanto v0.5.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -1645,8 +1645,8 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/storacha/go-libstoracha v0.2.0 h1:x3yz7PrTqVWT86hu/3OcKrS/72mLKfSdfIn8QoBw2rI=
 github.com/storacha/go-libstoracha v0.2.0/go.mod h1:68KXcak6CtWPKHlPV7emXbRbC+6LBiIWPbYrJ0urVf8=
-github.com/storacha/go-ucanto v0.4.2 h1:d9m9+a5W7U8VwIMqtGIwJOP3KZtEJOKNkQhveDczHEI=
-github.com/storacha/go-ucanto v0.4.2/go.mod h1:/I6qtE+oDHc+6lBc/glN+RFx0cbP/mDj4gihD7YezWc=
+github.com/storacha/go-ucanto v0.5.0 h1:BCYfTOjJ7DxmoGwpZn4N1XITWj1BdKIbk5Ok7kMoQ6I=
+github.com/storacha/go-ucanto v0.5.0/go.mod h1:/I6qtE+oDHc+6lBc/glN+RFx0cbP/mDj4gihD7YezWc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/service/storage/ucan/errors.go
+++ b/pkg/service/storage/ucan/errors.go
@@ -3,6 +3,8 @@ package ucan
 import (
 	"fmt"
 
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/result/failure/datamodel"
 	"github.com/storacha/go-ucanto/ucan"
 )
 
@@ -22,6 +24,12 @@ func (ue UnsupportedCapabilityError[C]) Error() string {
 	return fmt.Sprintf(`%s does not have a "%s" capability provider`, ue.capability.With(), ue.capability.Can())
 }
 
+func (ue UnsupportedCapabilityError[C]) ToIPLD() (ipld.Node, error) {
+	name := ue.Name()
+	model := datamodel.FailureModel{Name: &name, Message: ue.Error()}
+	return model.ToIPLD()
+}
+
 func NewUnsupportedCapabilityError[C any](capability ucan.Capability[C]) UnsupportedCapabilityError[C] {
 	return UnsupportedCapabilityError[C]{capability}
 }
@@ -39,6 +47,12 @@ func (be BlobSizeLimitExceededError) Error() string {
 	return fmt.Sprintf("Blob of %d bytes, exceeds size limit of %d bytes", be.size, be.max)
 }
 
+func (be BlobSizeLimitExceededError) ToIPLD() (ipld.Node, error) {
+	name := be.Name()
+	model := datamodel.FailureModel{Name: &name, Message: be.Error()}
+	return model.ToIPLD()
+}
+
 func NewBlobSizeLimitExceededError(size uint64, max uint64) BlobSizeLimitExceededError {
 	return BlobSizeLimitExceededError{size, max}
 }
@@ -51,6 +65,12 @@ func (ae AllocatedMemoryNotWrittenError) Name() string {
 
 func (ae AllocatedMemoryNotWrittenError) Error() string {
 	return "Blob not found"
+}
+
+func (ae AllocatedMemoryNotWrittenError) ToIPLD() (ipld.Node, error) {
+	name := ae.Name()
+	model := datamodel.FailureModel{Name: &name, Message: ae.Error()}
+	return model.ToIPLD()
 }
 
 func NewAllocatedMemoryNotWrittenError() AllocatedMemoryNotWrittenError {


### PR DESCRIPTION
The signature for handlers changed in go-ucanto. This PR updates Piri to use the new code.

Depends on https://github.com/storacha/go-ucanto/pull/55