### PR TITLE
feat(logging): add dynamic logging CLI and management API

### DIFF
--- a/cmd/cli/client/log.go
+++ b/cmd/cli/client/log.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/viper"
+)
+
+func SetLogLevel(ctx context.Context, subsystem, level string) error {
+	url := fmt.Sprintf("http://%s/log/level", viper.GetString("manage_api"))
+	jsonStr, err := json.Marshal(map[string]string{"subsystem": subsystem, "level": level})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to set log level: %s", resp.Status)
+	}
+
+	return nil
+}

--- a/cmd/cli/log.go
+++ b/cmd/cli/log.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"fmt"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/spf13/cobra"
+	"github.com/storacha/piri/cmd/cli/client"
+)
+
+var logListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all logging subsystems and their levels",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// List all registered subsystems
+		subsystems := logging.GetSubsystems()
+		for _, subsystem := range subsystems {
+			level := logging.Logger(subsystem).Level().String()
+			fmt.Printf("%-30s %s\n", subsystem, level)
+		}
+		return nil
+	},
+}
+
+var logSetLevelCmd = &cobra.Command{
+	Use:   "set-level <subsystem> <level>",
+	Short: "Set log level for a subsystem",
+	Args: func(cmd *cobra.Command, args []string) error {
+		all, err := cmd.Flags().GetBool("all")
+		if err != nil {
+			return err
+		}
+		if all {
+			return cobra.ExactArgs(1)(cmd, args)
+		}
+		return cobra.ExactArgs(2)(cmd, args)
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		all, err := cmd.Flags().GetBool("all")
+		if err != nil {
+			return err
+		}
+		if all {
+			level := args[0]
+			// get all subsystems
+			subsystems := logging.GetSubsystems()
+			for _, subsystem := range subsystems {
+				if err := client.SetLogLevel(cmd.Context(), subsystem, level); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		subsystem := args[0]
+		level := args[1]
+		return client.SetLogLevel(cmd.Context(), subsystem, level)
+	},
+}
+
+func init() {
+	logSetLevelCmd.Flags().Bool("all", false, "Set level for all subsystems")
+	LogCmd.AddCommand(logListCmd)
+	LogCmd.AddCommand(logSetLevelCmd)
+}
+
+var LogCmd = &cobra.Command{
+	Use:   "log",
+	Short: "Manage logging subsystems and levels",
+}

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -62,12 +62,16 @@ func init() {
 	cobra.CheckErr(rootCmd.MarkPersistentFlagFilename("key-file", "pem"))
 	cobra.CheckErr(viper.BindPFlag("key_file", rootCmd.PersistentFlags().Lookup("key-file")))
 
+	rootCmd.PersistentFlags().String("manage-api", "127.0.0.1:8888", "Management API address")
+	cobra.CheckErr(viper.BindPFlag("manage_api", rootCmd.PersistentFlags().Lookup("manage-api")))
+
 	// register all commands and their subcommands
 	rootCmd.AddCommand(serve.Cmd)
 	rootCmd.AddCommand(wallet.Cmd)
 	rootCmd.AddCommand(identity.Cmd)
 	rootCmd.AddCommand(delegate.Cmd)
 	rootCmd.AddCommand(client.Cmd)
+	rootCmd.AddCommand(LogCmd)
 
 }
 

--- a/cmd/cli/serve/full.go
+++ b/cmd/cli/serve/full.go
@@ -23,6 +23,7 @@ import (
 	"github.com/storacha/piri/pkg/config"
 	configapp "github.com/storacha/piri/pkg/config/app"
 	"github.com/storacha/piri/pkg/fx/app"
+	"github.com/storacha/piri/pkg/management"
 )
 
 var (
@@ -148,6 +149,9 @@ func startFullServer(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("transforming config: %w", err)
 	}
 
+	// Start the management server
+	startManagementServer(viper.GetString("manage_api"))
+
 	// Create the fx application with the app config
 	fxApp := fx.New(
 		fx.Supply(appConfig),
@@ -175,6 +179,16 @@ func startFullServer(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func startManagementServer(addr string) {
+	go func() {
+		log.Infof("starting management server on %s", addr)
+		mgtSrv := management.NewServer()
+		if err := mgtSrv.Start(addr); err != nil {
+			log.Errorf("failed to start management server: %s", err)
+		}
+	}()
 }
 
 // printHero prints the hero banner after startup

--- a/go.mod
+++ b/go.mod
@@ -296,7 +296,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.39.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
-	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1051,6 +1051,8 @@ github.com/ipfs/go-log/v2 v2.0.5/go.mod h1:eZs4Xt4ZUJQFM3DlanGhy7TkwwawCZcSByscw
 github.com/ipfs/go-log/v2 v2.1.3/go.mod h1:/8d0SH3Su5Ooc31QlL1WysJhvyOTDCjcCZ9Axpmri6g=
 github.com/ipfs/go-log/v2 v2.6.0 h1:2Nu1KKQQ2ayonKp4MPo6pXCjqw1ULc9iohRqWV5EYqg=
 github.com/ipfs/go-log/v2 v2.6.0/go.mod h1:p+Efr3qaY5YXpx9TX7MoLCSEZX5boSWj9wh86P5HJa8=
+github.com/ipfs/go-log/v2 v2.8.0 h1:SptNTPJQV3s5EF4FdrTu/yVdOKfGbDgn1EBZx4til2o=
+github.com/ipfs/go-log/v2 v2.8.0/go.mod h1:2LEEhdv8BGubPeSFTyzbqhCqrwqxCbuTNTLWqgNAipo=
 github.com/ipfs/go-merkledag v0.2.3/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
 github.com/ipfs/go-merkledag v0.2.4/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
 github.com/ipfs/go-merkledag v0.11.0 h1:DgzwK5hprESOzS4O1t/wi6JDpyVQdvm9Bs59N/jqfBY=
@@ -2237,6 +2239,8 @@ golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXctD9OcfyVLyj2J3IxLnKwHJR8f4D8a3YE=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/management/server.go
+++ b/pkg/management/server.go
@@ -1,0 +1,46 @@
+package management
+
+import (
+	"net/http"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/labstack/echo/v4"
+)
+
+func NewServer() *echo.Echo {
+	e := echo.New()
+	e.GET("/log/level", listLogLevels)
+	e.POST("/log/level", setLogLevel)
+	return e
+}
+
+func listLogLevels(c echo.Context) error {
+	levels := make(map[string]string)
+	for _, subsystem := range logging.GetSubsystems() {
+		levels[subsystem] = logging.Logger(subsystem).Level().String()
+	}
+	return c.JSON(http.StatusOK, levels)
+}
+
+func setLogLevel(c echo.Context) error {
+	var req struct {
+		Subsystem string `json:"subsystem"`
+		Level     string `json:"level"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+
+	if req.Subsystem == "" {
+		return c.String(http.StatusBadRequest, "subsystem is required")
+	}
+	if req.Level == "" {
+		return c.String(http.StatusBadRequest, "level is required")
+	}
+
+	if err := logging.SetLogLevel(req.Subsystem, req.Level); err != nil {
+		return c.String(http.StatusBadRequest, err.Error())
+	}
+
+	return c.NoContent(http.StatusOK)
+}


### PR DESCRIPTION
  This Pr closes this https://github.com/storacha/piri/issues/97
I have:

   * Created a new log command with list and set-level subcommands.
   * Created a management API server that exposes endpoints for listing and setting
      log levels.
   * Integrated the management server into the main application.
   * Used the cobra library to create the CLI commands.
   * Used the go-log/v2 library to manage logging.

  The log command can be used like this:
   * piri log list: Lists all logging subsystems and their current levels.
   * piri log set-level <subsystem> <level>: Sets the log level for a specific
     subsystem.
   * piri log set-level --all <level>: Sets the log level for all subsystems.
Please Note this is still a WIP and I still have some missing uint test implementation
