### PR TITLE
feat: print configuration details when starting servers

### DIFF
--- a/cmd/cli/serve/ucan.go
+++ b/cmd/cli/serve/ucan.go
@@ -261,6 +261,7 @@ func startServer(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("parsing indexing service URL: %w", err)
 	}
 
+	var opts []storage.Option
 	var indexingServiceProof delegation.Proof
 	if cfg.IndexingServiceProof != "" {
 		dlg, err := delegation.Parse(cfg.IndexingServiceProof)
@@ -268,6 +269,7 @@ func startServer(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("parsing indexing service proof: %w", err)
 		}
 		indexingServiceProof = delegation.FromDelegation(dlg)
+		opts = append(opts, storage.WithPublisherIndexingServiceProof(delegation.FromDelegation(dlg)))
 	}
 
 	var pubURL *url.URL
@@ -284,7 +286,7 @@ func startServer(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	opts := []storage.Option{
+	opts = append(opts,
 		storage.WithIdentity(id),
 		storage.WithBlobstore(blobStore),
 		storage.WithAllocationDatastore(allocDs),
@@ -294,9 +296,8 @@ func startServer(cmd *cobra.Command, _ []string) error {
 		storage.WithPublisherDirectAnnounce(ipniAnnounceURLs...),
 		storage.WithUploadServiceConfig(uploadServiceDID, *uploadServiceURL),
 		storage.WithPublisherIndexingServiceConfig(indexingServiceDID, *indexingServiceURL),
-		storage.WithPublisherIndexingServiceProof(indexingServiceProof),
 		storage.WithReceiptDatastore(receiptDs),
-	}
+	)
 	if pdpConfig != nil {
 		opts = append(opts, storage.WithPDPConfig(*pdpConfig))
 	}
@@ -312,6 +313,29 @@ func startServer(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("starting service: %w", err)
 	}
 
+	go func() {
+		serverConfig := cliutil.UCANServerConfig{
+			Host:                 cfg.Host,
+			Port:                 cfg.Port,
+			DataDir:              cfg.DataDir,
+			PublicURL:            pubURL,
+			BlobAddr:             blobAddr,
+			IndexingServiceDID:   indexingServiceDID,
+			IndexingServiceURL:   indexingServiceURL,
+			IndexingServiceProof: indexingServiceProof,
+			UploadServiceDID:     uploadServiceDID,
+			UploadServiceURL:     uploadServiceURL,
+			IPNIAnnounceURLs:     ipniAnnounceURLs,
+			PDPEnabled:           svc.PDP() != nil,
+		}
+		if svc.PDP() != nil {
+			serverConfig.PDPServerURL = pdpConfig.PDPServerURL
+			serverConfig.ProofSetID = pdpConfig.ProofSet
+		}
+		cliutil.PrintUCANServerConfig(cmd, serverConfig)
+		cliutil.PrintHero(id.DID())
+	}()
+
 	defer svc.Close(ctx)
 
 	presolv, err := principalresolver.NewHTTPResolver([]did.DID{indexingServiceDID, uploadServiceDID})
@@ -322,13 +346,6 @@ func startServer(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating cached principal resolver: %w", err)
 	}
-
-	go func() {
-		time.Sleep(time.Millisecond * 50)
-		if err == nil {
-			cliutil.PrintHero(id.DID())
-		}
-	}()
 
 	telemetry.RecordServerInfo(ctx, "ucan",
 		telemetry.StringAttr("did", id.DID().String()),

--- a/cmd/cliutil/util.go
+++ b/cmd/cliutil/util.go
@@ -2,10 +2,15 @@ package cliutil
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/labstack/gommon/color"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/spf13/cobra"
+	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/did"
 
 	"github.com/storacha/piri/pkg/build"
@@ -36,4 +41,85 @@ func Mkdirp(dirpath ...string) (string, error) {
 		return "", fmt.Errorf("creating directory: %s: %w", dir, err)
 	}
 	return dir, nil
+}
+
+type UCANServerConfig struct {
+	Host                 string
+	Port                 uint
+	DataDir              string
+	PublicURL            *url.URL
+	BlobAddr             multiaddr.Multiaddr
+	IndexingServiceDID   did.DID
+	IndexingServiceURL   *url.URL
+	IndexingServiceProof delegation.Proof
+	UploadServiceDID     did.DID
+	UploadServiceURL     *url.URL
+	IPNIAnnounceURLs     []url.URL
+	PDPEnabled           bool
+	PDPServerURL         *url.URL
+	ProofSetID           uint64
+}
+
+type PDPServerConfig struct {
+	Endpoint     *url.URL
+	LotusURL     *url.URL
+	OwnerAddress common.Address
+	DataDir      string
+}
+
+func PrintPDPServerConfig(cmd *cobra.Command, cfg PDPServerConfig) {
+	cmd.Println("SERVER CONFIGURATION")
+	cmd.Println("--------------------")
+	cmd.Printf("Endpoint:		%s\n", cfg.Endpoint.String())
+	cmd.Printf("Data Dir:		%s\n", cfg.DataDir)
+	cmd.Printf("Lotus Endpoint:		%s\n", cfg.LotusURL.String())
+	cmd.Printf("Owner Address:		%s\n", cfg.OwnerAddress.String())
+	cmd.Println()
+}
+
+func PrintUCANServerConfig(cmd *cobra.Command, cfg UCANServerConfig) {
+	cmd.Println("SERVER CONFIGURATION")
+	cmd.Println("--------------------")
+	cmd.Printf("Host:        %s\n", cfg.Host)
+	cmd.Printf("Port:        %d\n", cfg.Port)
+	cmd.Printf("Data Dir:    %s\n", cfg.DataDir)
+	cmd.Printf("Public URL:  %s\n", cfg.PublicURL)
+	if cfg.BlobAddr != nil {
+		cmd.Printf("Blob Addr:   %s\n", cfg.BlobAddr)
+	}
+
+	cmd.Println()
+	cmd.Println("SERVICES")
+	cmd.Println("--------")
+	cmd.Println("Indexing Service:")
+	cmd.Printf("  DID:       %s\n", cfg.IndexingServiceDID)
+	cmd.Printf("  URL:       %s\n", cfg.IndexingServiceURL)
+	cmd.Printf("  Proof Set: %t\n", cfg.IndexingServiceProof != delegation.Proof{})
+	cmd.Println()
+	cmd.Println("Upload Service:")
+	cmd.Printf("  DID:       %s\n", cfg.UploadServiceDID)
+	cmd.Printf("  URL:       %s\n", cfg.UploadServiceURL)
+
+	cmd.Println()
+	cmd.Println("IPNI ANNOUNCE URLS")
+	cmd.Println("------------------")
+	if len(cfg.IPNIAnnounceURLs) == 0 {
+		cmd.Println("  (none configured)")
+	} else {
+		for _, url := range cfg.IPNIAnnounceURLs {
+			cmd.Printf("  • %s\n", url.String())
+		}
+	}
+
+	cmd.Println()
+	if cfg.PDPEnabled {
+		cmd.Println("PDP CONFIGURATION")
+		cmd.Println("-----------------")
+		cmd.Println("Status:      Enabled")
+		cmd.Printf("Server URL:  %s\n", cfg.PDPServerURL)
+		cmd.Printf("Proof Set:   %d\n", cfg.ProofSetID)
+	} else {
+		cmd.Println("PDP Status:  Disabled")
+	}
+	cmd.Println()
 }

--- a/pkg/pdp/server.go
+++ b/pkg/pdp/server.go
@@ -61,7 +61,7 @@ func NewServer(
 	ctx context.Context,
 	dataDir string,
 	endpoint *url.URL,
-	lotusUrl string,
+	lotusEndpoint *url.URL,
 	address common.Address,
 	wlt *wallet.LocalWallet,
 ) (*Server, error) {
@@ -82,19 +82,15 @@ func NewServer(
 	// TODO our current in process endpoint, later create a client without http stuffs.
 	// NB: Auth not required
 	localPDPClient := curio.New(http.DefaultClient, endpoint, "")
-	lotusURL, err := url.Parse(lotusUrl)
-	if err != nil {
-		return nil, fmt.Errorf("parsing lotus client address: %w", err)
+	if lotusEndpoint.Scheme != "ws" && lotusEndpoint.Scheme != "wss" {
+		return nil, fmt.Errorf("lotus client address must be 'ws' or 'wss', got %s", lotusEndpoint.Scheme)
 	}
-	if lotusURL.Scheme != "ws" && lotusURL.Scheme != "wss" {
-		return nil, fmt.Errorf("lotus client address must be 'ws' or 'wss', got %s", lotusURL.Scheme)
-	}
-	chainClient, chainClientCloser, err := client.NewFullNodeRPCV1(ctx, lotusURL.String(), nil)
+	chainClient, chainClientCloser, err := client.NewFullNodeRPCV1(ctx, lotusEndpoint.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	ethClient, err := ethclient.Dial(lotusUrl)
+	ethClient, err := ethclient.Dial(lotusEndpoint.String())
 	if err != nil {
 		return nil, fmt.Errorf("connecting to eth client: %w", err)
 	}


### PR DESCRIPTION
Goal: make it easier for user to understand their current server(s) configuration. Also makes sharing configuration for debugging easier.

When starting a UCAN Server, the output is now:
```bash
piri serve ucan --key-file=service.pem --pdp-server-url=http://localhost:3001 --proof-set=514

SERVER CONFIGURATION
--------------------
Host:        localhost
Port:        3000
Data Dir:    /home/frrist/.storacha
Public URL:  http://localhost:3000
Blob Addr:   /dns/localhost/tcp/3001/http/http-path/piece%2F%7BblobCID%7D

SERVICES
--------
Indexing Service:
  DID:       did:web:staging.indexer.warm.storacha.network
  URL:       https://staging.indexer.warm.storacha.network
  Proof Set: false

Upload Service:
  DID:       did:web:staging.up.warm.storacha.network
  URL:       https://staging.up.warm.storacha.network

IPNI ANNOUNCE URLS
------------------
  • https://cid.contact/announce
  • https://staging.ipni.warm.storacha.network

PDP CONFIGURATION
-----------------
Status:      Enabled
Server URL:  http://localhost:3001
Proof Set:   514


▗▄▄▖ ▄  ▄▄▄ ▄   ▗
▐▌ ▐▌▄ █    ▄   █▌
▐▛▀▘ █ █    █  ▗█▘
▐▌   █      █  ▀▘

🔥 v0.0.11-a3426b2-dirty
🆔 did:key:z6MktKFLaLfEEisRzdLjRQXwzAMrfdvgYF8rBsgotdhTXTri
🚀 Ready!
```

If the PDP server isn't configured on the UCAN server, output becomes:
```bash
piri serve ucan --key-file=service.pem 

SERVER CONFIGURATION
--------------------
Host:        localhost
Port:        3000
Data Dir:    /home/frrist/.storacha
Public URL:  http://localhost:3000

SERVICES
--------
Indexing Service:
  DID:       did:web:staging.indexer.warm.storacha.network
  URL:       https://staging.indexer.warm.storacha.network
  Proof Set: false

Upload Service:
  DID:       did:web:staging.up.warm.storacha.network
  URL:       https://staging.up.warm.storacha.network

IPNI ANNOUNCE URLS
------------------
  • https://cid.contact/announce
  • https://staging.ipni.warm.storacha.network

PDP Status:  Disabled


▗▄▄▖ ▄  ▄▄▄ ▄   ▗
▐▌ ▐▌▄ █    ▄   █▌
▐▛▀▘ █ █    █  ▗█▘
▐▌   █      █  ▀▘

🔥 v0.0.11-a3426b2-dirty
🆔 did:key:z6MktKFLaLfEEisRzdLjRQXwzAMrfdvgYF8rBsgotdhTXTri
🚀 Ready!
```


When starting a PDP Server, the output is now:
```bash
piri serve pdp --lotus-url=wss://lotus.spicystorage.tech/rpc/v1 --eth-address=0x7469B47e006D0660aB92AE560b27A1075EEcF97F

SERVER CONFIGURATION
--------------------
Endpoint:               http://localhost:3001
Data Dir:               /home/frrist/.storacha
Lotus Endpoint:         wss://lotus.spicystorage.tech/rpc/v1
Owner Address:          0x7469B47e006D0660aB92AE560b27A1075EEcF97F

Server started! Listening on  http://localhost:3001
```