### PR TITLE
fix(docs): --proof-set is required when using --pdp-server-url

### DIFF
--- a/docs/guides/ucan-server.md
+++ b/docs/guides/ucan-server.md
@@ -83,10 +83,12 @@ source .env
 #### 4.3 Restart your Piri node
 
 ```bash
-piri serve ucan --key-file=service.pem --pdp-server-url=https://up.piri.example.com
+piri serve ucan --key-file=service.pem --pdp-server-url=https://up.piri.example.com --proof-set=123
 ```
 
-> **Note**: Replace `up.piri.example.com` with your actual PDP server domain configured in the [TLS Termination](../setup/tls-termination.md) section.
+> **Note**:
+> - Replace `up.piri.example.com` with your actual PDP server domain configured in the [TLS Termination](../setup/tls-termination.md) section.
+> - Replace `123` with the proof set ID you got when [a new proofset was created](./pdp-server.md#step-3-create-a-proof-set) as part of configuring the PDP server.
 
 **Expected output:**
 ```bash


### PR DESCRIPTION
My piri version was very old and I went over the docs again. `piri serve ucan` complained that `--proof-set` is required when using `--pdp-server-url`, so I added that to the command in the docs.