### PR TITLE
feat: implement `proofset list` cli/client/api

### DIFF
--- a/cmd/cli/client/pdp/proofset/list.go
+++ b/cmd/cli/client/pdp/proofset/list.go
@@ -1,0 +1,46 @@
+package proofset
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/storacha/piri/pkg/config"
+	"github.com/storacha/piri/pkg/pdp/httpapi/client"
+)
+
+var (
+	ListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List all proof sets",
+		Args:  cobra.NoArgs,
+		RunE:  doList,
+	}
+)
+
+func doList(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	cfg, err := config.Load[config.PDPClient]()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	api, err := client.NewFromConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("creating client: %w", err)
+	}
+
+	proofSet, err := api.ListProofSet(ctx)
+	if err != nil {
+		return fmt.Errorf("getting proof set status: %w", err)
+	}
+	jsonProofSet, err := json.MarshalIndent(proofSet, "", "  ")
+	if err != nil {
+		return fmt.Errorf("rendering json: %w", err)
+	}
+	fmt.Print(string(jsonProofSet))
+	return nil
+
+}

--- a/cmd/cli/client/pdp/proofset/root.go
+++ b/cmd/cli/client/pdp/proofset/root.go
@@ -16,4 +16,5 @@ func init() {
 	Cmd.AddCommand(CreateCmd)
 	Cmd.AddCommand(StatusCmd)
 	Cmd.AddCommand(GetCmd)
+	Cmd.AddCommand(ListCmd)
 }

--- a/pkg/pdp/httpapi/server/list_proofset.go
+++ b/pkg/pdp/httpapi/server/list_proofset.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/storacha/piri/pkg/pdp/httpapi"
+)
+
+// handleListProofSet -> GET /pdp/proof-sets
+func (p *PDP) handleListProofSet(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	ps, err := p.Service.ListProofSets(ctx)
+	if err != nil {
+		return err
+	}
+
+	var resp httpapi.ListProofSetsResponse
+	for _, p := range ps {
+		entry := httpapi.ProofSetEntry{
+			ID:                     p.ID,
+			Initialized:            p.Initialized,
+			NextChallengeEpoch:     &p.NextChallengeEpoch,
+			PreviousChallengeEpoch: &p.PreviousChallengeEpoch,
+			ProvingPeriod:          &p.ProvingPeriod,
+			ChallengeWindow:        &p.ChallengeWindow,
+		}
+		for _, root := range p.Roots {
+			entry.Roots = append(entry.Roots, httpapi.RootEntry{
+				RootID:        root.RootID,
+				RootCID:       root.RootCID.String(),
+				SubrootCID:    root.SubrootCID.String(),
+				SubrootOffset: root.SubrootOffset,
+			})
+		}
+		resp = append(resp, entry)
+	}
+	return c.JSON(http.StatusOK, resp)
+}

--- a/pkg/pdp/httpapi/server/register.go
+++ b/pkg/pdp/httpapi/server/register.go
@@ -26,6 +26,7 @@ func RegisterEchoRoutes(e *echo.Echo, p *PDP) {
 	// /pdp/proof-sets/:proofSetID
 	proofSets.GET("/:proofSetID", p.handleGetProofSet)
 	proofSets.DELETE("/:proofSetID", p.handleDeleteProofSet)
+	proofSets.GET("", p.handleListProofSet)
 
 	// /pdp/proof-sets/:proofSetID/roots
 	roots := proofSets.Group("/:proofSetID/roots")

--- a/pkg/pdp/httpapi/types.go
+++ b/pkg/pdp/httpapi/types.go
@@ -47,6 +47,19 @@ type (
 	}
 )
 
+type (
+	ListProofSetsResponse []ProofSetEntry
+	ProofSetEntry         struct {
+		ID                     uint64      `json:"id"`
+		Initialized            bool        `json:"initialized"`
+		Roots                  []RootEntry `json:"roots"`
+		NextChallengeEpoch     *int64      `json:"nextChallengeEpoch,omitempty"`
+		PreviousChallengeEpoch *int64      `json:"previousChallengeEpoch,omitempty"`
+		ProvingPeriod          *int64      `json:"provingPeriod,omitempty"`
+		ChallengeWindow        *int64      `json:"challengeWindow,omitempty"`
+	}
+)
+
 // AddRoots types
 type (
 	AddRootsRequest struct {

--- a/pkg/pdp/service/proofset_list.go
+++ b/pkg/pdp/service/proofset_list.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	"gorm.io/gorm"
+
+	"github.com/storacha/piri/pkg/pdp/service/models"
+	"github.com/storacha/piri/pkg/pdp/types"
+)
+
+func (p *PDPService) ListProofSets(ctx context.Context) ([]types.ProofSet, error) {
+	var proofSets []models.PDPProofSet
+	if err := p.db.
+		WithContext(ctx).
+		Where("service = ?", p.name).
+		Find(&proofSets).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, types.NewErrorf(types.KindNotFound, "no proof sets found")
+		}
+		return nil, fmt.Errorf("failed to retrieve proof sets: %w", err)
+	}
+
+	// Build the response for each proof set
+	result := make([]types.ProofSet, 0, len(proofSets))
+	for _, proofSet := range proofSets {
+		// Retrieve the roots associated with the proof set
+		var roots []models.PDPProofsetRoot
+		if err := p.db.WithContext(ctx).
+			Where("proofset_id = ?", proofSet.ID).
+			Order("root_id, subroot_offset").
+			Find(&roots).Error; err != nil {
+			return nil, fmt.Errorf("failed to retrieve proof set roots for proof set %d: %w", proofSet.ID, err)
+		}
+
+		// Build the response
+		response := types.ProofSet{
+			ID:          uint64(proofSet.ID),
+			Initialized: proofSet.InitReady,
+		}
+		for _, r := range roots {
+			rootCid, err := cid.Decode(r.Root)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode root cid %s for proof set %d: %w", r.Root, proofSet.ID, err)
+			}
+			subrootCid, err := cid.Decode(r.Subroot)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode subroot cid %s for proof set %d: %w", r.Subroot, proofSet.ID, err)
+			}
+			response.Roots = append(response.Roots, types.RootEntry{
+				RootID:        uint64(r.RootID),
+				RootCID:       rootCid,
+				SubrootCID:    subrootCid,
+				SubrootOffset: r.SubrootOffset,
+			})
+		}
+		if proofSet.ProveAtEpoch != nil {
+			response.NextChallengeEpoch = *proofSet.ProveAtEpoch
+		}
+		if proofSet.PrevChallengeRequestEpoch != nil {
+			response.PreviousChallengeEpoch = *proofSet.PrevChallengeRequestEpoch
+		}
+		if proofSet.ProvingPeriod != nil {
+			response.ProvingPeriod = *proofSet.ProvingPeriod
+		}
+		if proofSet.ChallengeWindow != nil {
+			response.ChallengeWindow = *proofSet.ChallengeWindow
+		}
+
+		result = append(result, response)
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
allows users to list the proofsets their node is currently configured with. This will come in handy w/ later PRs where we init a node and a proofset automatically if one doesn't exist when a "full" node starts. The intention here is to use this API on startup in a later PR.