### PR TITLE
fix: explicitly log handler execution errors

### DIFF
--- a/cmd/cli/serve/ucan.go
+++ b/cmd/cli/serve/ucan.go
@@ -365,6 +365,13 @@ func startServer(cmd *cobra.Command, _ []string) error {
 		fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),
 		svc,
 		ucanserver.WithPrincipalResolver(cachedpresolv.ResolveDIDKey),
+		ucanserver.WithErrorHandler(func(err ucanserver.HandlerExecutionError[any]) {
+			log.Error(err.Error())
+			stack := err.Stack()
+			if stack != "" {
+				log.Error(stack)
+			}
+		}),
 	)
 	return err
 

--- a/cmd/cli/serve/ucan.go
+++ b/cmd/cli/serve/ucan.go
@@ -366,11 +366,11 @@ func startServer(cmd *cobra.Command, _ []string) error {
 		svc,
 		ucanserver.WithPrincipalResolver(cachedpresolv.ResolveDIDKey),
 		ucanserver.WithErrorHandler(func(err ucanserver.HandlerExecutionError[any]) {
-			log.Error(err.Error())
-			stack := err.Stack()
-			if stack != "" {
-				log.Error(stack)
+			l := log.With("error", err.Error())
+			if s := err.Stack(); s != "" {
+				l.With("stack", s)
 			}
+			l.Error("ucan handler execution error")
 		}),
 	)
 	return err


### PR DESCRIPTION
Unexpected errors from handlers are sent to this function, [by default it prints to stderr](https://github.com/storacha/go-ucanto/blob/cd24d1a476ed38d5a70d443c60e0f11b361ff1f7/server/server.go#L106). This PR explicitly logs the error using our logger and prints the stack trace if the underlying cause had a stack trace.