### PR TITLE
feat: add node version to help flag output

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -43,13 +43,15 @@ var (
 	cfgFile  string
 	logLevel string
 	rootCmd  = &cobra.Command{
-		Use:   "piri",
-		Short: piriShortDescription,
-		Long:  piriLongDescription,
+		Use:     "piri",
+		Short:   piriShortDescription,
+		Long:    piriLongDescription,
+		Version: buildVersion("  "),
 	}
 )
 
 func init() {
+	initHelp()
 	cobra.OnInitialize(initLogging, initConfig, initTelemetry)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file path")
@@ -79,6 +81,25 @@ func init() {
 	rootCmd.AddCommand(initalize.InitCmd)
 	rootCmd.AddCommand(client.Cmd)
 
+}
+
+func initHelp() {
+	rootCmd.SetHelpTemplate(`{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}{{end}}
+
+Version: 
+{{.Version}}
+
+Usage:
+  {{.UseLine}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.
+`)
 }
 
 func initConfig() {

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -13,11 +13,18 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version of piri",
 	Long:  `Print the version of piri including the git revision.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("version: %s\n", build.Version)
-		fmt.Printf("commit: %s\n", build.Commit)
-		fmt.Printf("built at: %s\n", build.Date)
-		fmt.Printf("built by: %s\n", build.BuiltBy)
+		fmt.Println(buildVersion(""))
 	},
+}
+
+func buildVersion(indent string) string {
+	return fmt.Sprintf(
+		"%sversion: %s\n%scommit: %s\n%sbuilt at: %s\n%sbuilt by: %s",
+		indent, build.Version,
+		indent, build.Commit,
+		indent, build.Date,
+		indent, build.BuiltBy,
+	)
 }
 
 func init() {


### PR DESCRIPTION
This includes the version of the node in the output when `piri --help` is run. 

closes #151 