### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -35,7 +35,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.prepare-checkout.outputs.ref }}
       - name: Set up Docker Buildx

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Go

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -101,7 +101,7 @@ jobs:
   terraform:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates.
Requires runner v2.327.1+. Workflows compile the same.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0