### PR TITLE
Implement graceful shutdown of job queue w/ OnFailure method

### DIFF
--- a/pkg/fx/aggregator/provider.go
+++ b/pkg/fx/aggregator/provider.go
@@ -76,8 +76,7 @@ func ProvideLinkQueue(lc fx.Lifecycle, params LinkQueueParams) (*jobqueue.JobQue
 	queueCtx, cancel := context.WithCancel(context.Background())
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			linkQueue.Start(queueCtx)
-			return nil
+			return linkQueue.Start(queueCtx)
 		},
 		OnStop: func(ctx context.Context) error {
 			cancel()
@@ -95,8 +94,7 @@ func ProvidePieceQueue(lc fx.Lifecycle, params LinkQueueParams) (*jobqueue.JobQu
 	queueCtx, cancel := context.WithCancel(context.Background())
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			pieceQueue.Start(queueCtx)
-			return nil
+			return pieceQueue.Start(queueCtx)
 		},
 		OnStop: func(ctx context.Context) error {
 			cancel()

--- a/pkg/fx/aggregator/provider.go
+++ b/pkg/fx/aggregator/provider.go
@@ -76,12 +76,12 @@ func ProvideLinkQueue(lc fx.Lifecycle, params LinkQueueParams) (*jobqueue.JobQue
 	queueCtx, cancel := context.WithCancel(context.Background())
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			go linkQueue.Start(queueCtx)
+			linkQueue.Start(queueCtx)
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
 			cancel()
-			return nil
+			return linkQueue.Stop(ctx)
 		},
 	})
 	return linkQueue, nil
@@ -95,12 +95,12 @@ func ProvidePieceQueue(lc fx.Lifecycle, params LinkQueueParams) (*jobqueue.JobQu
 	queueCtx, cancel := context.WithCancel(context.Background())
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			go pieceQueue.Start(queueCtx)
+			pieceQueue.Start(queueCtx)
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
 			cancel()
-			return nil
+			return pieceQueue.Stop(ctx)
 		},
 	})
 	return pieceQueue, nil

--- a/pkg/fx/replicator/provider.go
+++ b/pkg/fx/replicator/provider.go
@@ -59,8 +59,7 @@ func ProvideReplicationQueue(lc fx.Lifecycle, params QueueParams) (*jobqueue.Job
 	queueCtx, cancel := context.WithCancel(context.Background())
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
-			replicationQueue.Start(queueCtx)
-			return nil
+			return replicationQueue.Start(queueCtx)
 		},
 		OnStop: func(ctx context.Context) error {
 			cancel()                          // Cancel the Start context first

--- a/pkg/fx/replicator/provider.go
+++ b/pkg/fx/replicator/provider.go
@@ -4,26 +4,72 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"runtime"
 
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/storacha/go-ucanto/principal"
 	"go.uber.org/fx"
 
 	"github.com/storacha/piri/pkg/config/app"
 	"github.com/storacha/piri/pkg/pdp"
+	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue"
+	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue/serializer"
 	"github.com/storacha/piri/pkg/service/blobs"
 	"github.com/storacha/piri/pkg/service/claims"
 	"github.com/storacha/piri/pkg/service/replicator"
+	replicahandler "github.com/storacha/piri/pkg/service/storage/handlers/replica"
 	"github.com/storacha/piri/pkg/store/receiptstore"
 )
 
+var log = logging.Logger("replicator")
+
 var Module = fx.Module("replicator",
 	fx.Provide(
+		ProvideReplicationQueue,
 		fx.Annotate(
 			New,
-			fx.As(new(replicator.Replicator)),
+			fx.As(fx.Self()),                  // provide as concrete type for RegisterReplicationJobs
+			fx.As(new(replicator.Replicator)), // also provide as interface
 		),
 	),
+	fx.Invoke(
+		RegisterReplicationJobs,
+	),
 )
+
+type QueueParams struct {
+	fx.In
+	DB *sql.DB `name:"replicator_db"`
+}
+
+func ProvideReplicationQueue(lc fx.Lifecycle, params QueueParams) (*jobqueue.JobQueue[*replicahandler.TransferRequest], error) {
+	replicationQueue, err := jobqueue.New[*replicahandler.TransferRequest](
+		"replication",
+		params.DB,
+		&serializer.JSON[*replicahandler.TransferRequest]{},
+		jobqueue.WithLogger(log.With("queue", "replication")),
+		// TODO make these values configurable by users, with sane defaults
+		jobqueue.WithMaxRetries(10),
+		jobqueue.WithMaxWorkers(uint(runtime.NumCPU())),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating replication queue: %w", err)
+	}
+
+	queueCtx, cancel := context.WithCancel(context.Background())
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			replicationQueue.Start(queueCtx)
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			cancel()                          // Cancel the Start context first
+			return replicationQueue.Stop(ctx) // Then wait for graceful shutdown
+		},
+	})
+
+	return replicationQueue, nil
+}
 
 type Params struct {
 	fx.In
@@ -34,10 +80,10 @@ type Params struct {
 	Blobs        blobs.Blobs
 	Claims       claims.Claims
 	ReceiptStore receiptstore.ReceiptStore
-	DB           *sql.DB `name:"replicator_db"`
+	Queue        *jobqueue.JobQueue[*replicahandler.TransferRequest]
 }
 
-func New(params Params, lc fx.Lifecycle) (*replicator.Service, error) {
+func New(params Params) (*replicator.Service, error) {
 	r, err := replicator.New(
 		params.ID,
 		params.PDP,
@@ -45,24 +91,18 @@ func New(params Params, lc fx.Lifecycle) (*replicator.Service, error) {
 		params.Claims,
 		params.ReceiptStore,
 		params.Config.UCANService.Services.Upload.Connection,
-		params.DB,
+		params.Queue,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new replicator: %w", err)
 	}
 
-	lc.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
-			// NB(forrest): accept a context todo since the lifecycle hook context has a timeout of 10 sec for starting
-			// a service, we don't want the replicator to timeout here.
-			// Long term fix is for replicator start to accept a contex scoped only for startup operation, or none at all
-			// since it has a dedicated stop method
-			return r.Start(context.TODO())
-		},
-		OnStop: func(ctx context.Context) error {
-			return r.Stop(ctx)
-		},
-	})
-
 	return r, nil
+}
+
+func RegisterReplicationJobs(
+	queue *jobqueue.JobQueue[*replicahandler.TransferRequest],
+	service *replicator.Service,
+) error {
+	return service.RegisterTransferTask(queue)
 }

--- a/pkg/pdp/aggregator/jobqueue/jobqueue.go
+++ b/pkg/pdp/aggregator/jobqueue/jobqueue.go
@@ -20,7 +20,7 @@ var log = logging.Logger("jobqueue")
 type Service[T any] interface {
 	Start(ctx context.Context)
 	Stop(ctx context.Context) error
-	Register(name string, fn func(context.Context, T) error) error
+	Register(name string, fn func(context.Context, T) error, opts ...worker.JobOption[T]) error
 	Enqueue(ctx context.Context, name string, msg T) error
 }
 
@@ -145,8 +145,8 @@ func (j *JobQueue[T]) Start(ctx context.Context) {
 	}()
 }
 
-func (j *JobQueue[T]) Register(name string, fn func(context.Context, T) error) error {
-	return j.worker.Register(name, fn)
+func (j *JobQueue[T]) Register(name string, fn func(context.Context, T) error, opts ...worker.JobOption[T]) error {
+	return j.worker.Register(name, fn, opts...)
 }
 
 func (j *JobQueue[T]) Enqueue(ctx context.Context, name string, msg T) error {
@@ -193,4 +193,10 @@ func (j *JobQueue[T]) Stop(ctx context.Context) error {
 		log.Infof("JobQueue[%s] stopped successfully - all tasks completed", j.name)
 		return nil
 	}
+}
+
+// WithOnFailure re-exports the worker.WithOnFailure function for convenience
+// This allows consumers to use jobqueue.WithOnFailure without importing the worker package directly
+func WithOnFailure[T any](onFailure worker.OnFailureFn[T]) worker.JobOption[T] {
+	return worker.WithOnFailure[T](onFailure)
 }

--- a/pkg/pdp/aggregator/jobqueue/jobqueue.go
+++ b/pkg/pdp/aggregator/jobqueue/jobqueue.go
@@ -185,9 +185,7 @@ func (j *JobQueue[T]) Stop(ctx context.Context) error {
 	log.Infof("JobQueue[%s] stopping - no new tasks will be accepted", j.name)
 
 	// Cancel the start context to signal worker to stop
-	if j.startCancel != nil {
-		j.startCancel()
-	}
+	j.startCancel()
 	j.mu.Unlock()
 
 	log.Infof("JobQueue[%s] waiting for active tasks to complete", j.name)
@@ -209,8 +207,8 @@ func (j *JobQueue[T]) Stop(ctx context.Context) error {
 	}
 }
 
-// WithOnFailure re-exports the worker.WithOnFailure function for convenience
-// This allows consumers to use jobqueue.WithOnFailure without importing the worker package directly
+// WithOnFailure sets a callback to be invoked only when the job fails after max retries
+// The JobQueue only supports a single OnFailure callback for a job, multiple OnFailure options must not be provided.
 func WithOnFailure[T any](onFailure worker.OnFailureFn[T]) worker.JobOption[T] {
 	return worker.WithOnFailure[T](onFailure)
 }

--- a/pkg/pdp/aggregator/jobqueue/jobqueue.go
+++ b/pkg/pdp/aggregator/jobqueue/jobqueue.go
@@ -5,15 +5,21 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
+
+	logging "github.com/ipfs/go-log/v2"
 
 	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue/queue"
 	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue/serializer"
 	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue/worker"
 )
 
+var log = logging.Logger("jobqueue")
+
 type Service[T any] interface {
 	Start(ctx context.Context)
+	Stop(ctx context.Context) error
 	Register(name string, fn func(context.Context, T) error) error
 	Enqueue(ctx context.Context, name string, msg T) error
 }
@@ -66,6 +72,14 @@ func WithMaxTimeout(maxTimeout time.Duration) Option {
 type JobQueue[T any] struct {
 	worker *worker.Worker[T]
 	queue  *queue.Queue
+	name   string
+
+	// shutdown management
+	mu          sync.RWMutex
+	stopping    bool
+	startCtx    context.Context
+	startCancel context.CancelFunc
+	startWg     sync.WaitGroup
 }
 
 func New[T any](name string, db *sql.DB, ser serializer.Serializer[T], opts ...Option) (*JobQueue[T], error) {
@@ -107,11 +121,28 @@ func New[T any](name string, db *sql.DB, ser serializer.Serializer[T], opts ...O
 	return &JobQueue[T]{
 		queue:  q,
 		worker: w,
+		name:   name,
 	}, nil
 }
 
 func (j *JobQueue[T]) Start(ctx context.Context) {
-	j.worker.Start(ctx)
+	j.mu.Lock()
+	if j.startCtx != nil {
+		// Already started
+		log.Warnf("JobQueue[%s] already started, ignoring Start call", j.name)
+		j.mu.Unlock()
+		return
+	}
+	j.startCtx, j.startCancel = context.WithCancel(ctx)
+	j.startWg.Add(1)
+	j.mu.Unlock()
+
+	log.Infof("JobQueue[%s] starting", j.name)
+	go func() {
+		defer j.startWg.Done()
+		j.worker.Start(j.startCtx)
+		log.Infof("JobQueue[%s] worker stopped", j.name)
+	}()
 }
 
 func (j *JobQueue[T]) Register(name string, fn func(context.Context, T) error) error {
@@ -119,5 +150,47 @@ func (j *JobQueue[T]) Register(name string, fn func(context.Context, T) error) e
 }
 
 func (j *JobQueue[T]) Enqueue(ctx context.Context, name string, msg T) error {
+	j.mu.RLock()
+	if j.stopping {
+		j.mu.RUnlock()
+		log.Debugf("JobQueue[%s] rejecting enqueue of %s - queue is stopping", j.name, name)
+		return errors.New("job queue is stopping")
+	}
+	j.mu.RUnlock()
 	return j.worker.Enqueue(ctx, name, msg)
+}
+
+func (j *JobQueue[T]) Stop(ctx context.Context) error {
+	j.mu.Lock()
+	if j.stopping {
+		j.mu.Unlock()
+		log.Warnf("JobQueue[%s] already stopping, ignoring Stop call", j.name)
+		return errors.New("job queue is already stopping")
+	}
+	j.stopping = true
+	log.Infof("JobQueue[%s] stopping - no new tasks will be accepted", j.name)
+
+	// Cancel the start context to signal worker to stop
+	if j.startCancel != nil {
+		j.startCancel()
+	}
+	j.mu.Unlock()
+
+	log.Infof("JobQueue[%s] waiting for active tasks to complete", j.name)
+
+	// Wait for the worker to finish processing all running tasks
+	done := make(chan struct{})
+	go func() {
+		j.startWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Errorf("JobQueue[%s] stop timeout - some tasks may not have completed gracefully", j.name)
+		return fmt.Errorf("stop timeout: %w", ctx.Err())
+	case <-done:
+		log.Infof("JobQueue[%s] stopped successfully - all tasks completed", j.name)
+		return nil
+	}
 }

--- a/pkg/pdp/aggregator/jobqueue/jobqueue_test.go
+++ b/pkg/pdp/aggregator/jobqueue/jobqueue_test.go
@@ -1,0 +1,404 @@
+package jobqueue_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue"
+	internaltesting "github.com/storacha/piri/pkg/pdp/aggregator/jobqueue/internal/testing"
+	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue/queue"
+	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue/serializer"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMessage is a simple test message type
+type TestMessage struct {
+	ID      string
+	Payload string
+	Delay   time.Duration
+}
+
+// newTestJobQueue creates a new JobQueue for testing
+func newTestJobQueue(t *testing.T, db *sql.DB, opts ...jobqueue.Option) *jobqueue.JobQueue[TestMessage] {
+	t.Helper()
+	if db == nil {
+		db = internaltesting.NewInMemoryDB(t)
+		// Setup queue schema
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+		require.NoError(t, queue.Setup(ctx, db))
+	}
+
+	ser := serializer.JSON[TestMessage]{}
+	jq, err := jobqueue.New[TestMessage]("test-queue", db, ser, opts...)
+	require.NoError(t, err)
+	return jq
+}
+
+func TestJobQueue_Stop_GracefulShutdown(t *testing.T) {
+	t.Run("waits for running tasks to complete", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil, jobqueue.WithMaxWorkers(1))
+
+		var taskCompleted atomic.Bool
+		taskStarted := make(chan struct{})
+
+		// Register a task that takes some time
+		err := jq.Register("task", func(ctx context.Context, msg TestMessage) error {
+			close(taskStarted)
+			// Simulate work that takes time
+			time.Sleep(500 * time.Millisecond)
+			taskCompleted.Store(true)
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Start the queue
+		ctx := context.Background()
+		jq.Start(ctx)
+
+		// Enqueue a task
+		err = jq.Enqueue(ctx, "task", TestMessage{ID: "1", Payload: "test"})
+		require.NoError(t, err)
+
+		// Wait for task to start
+		select {
+		case <-taskStarted:
+			// Task is running
+		case <-time.After(2 * time.Second):
+			t.Fatal("Task did not start")
+		}
+
+		// Stop the queue (should wait for task to complete)
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		err = jq.Stop(stopCtx)
+		require.NoError(t, err)
+
+		// Verify task was allowed to complete
+		require.True(t, taskCompleted.Load(), "Task should have completed before Stop returned")
+	})
+}
+
+func TestJobQueue_Stop_RejectsNewTasks(t *testing.T) {
+	t.Run("rejects enqueue after Stop is called", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil)
+
+		// Register a simple task
+		err := jq.Register("simple-task", func(ctx context.Context, msg TestMessage) error {
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Start and immediately stop
+		ctx := context.Background()
+		jq.Start(ctx)
+
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		err = jq.Stop(stopCtx)
+		require.NoError(t, err)
+
+		// Try to enqueue a task after stopping
+		err = jq.Enqueue(ctx, "simple-task", TestMessage{ID: "1", Payload: "test"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "job queue is stopping")
+	})
+}
+
+func TestJobQueue_Stop_ContextTimeout(t *testing.T) {
+	t.Run("returns timeout error when context expires", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil, jobqueue.WithMaxWorkers(1))
+
+		blockForever := make(chan struct{})
+
+		// Register a task that blocks forever
+		err := jq.Register("block-forever", func(ctx context.Context, msg TestMessage) error {
+			<-blockForever
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Start the queue
+		ctx := context.Background()
+		jq.Start(ctx)
+
+		// Enqueue a blocking task
+		err = jq.Enqueue(ctx, "block-forever", TestMessage{ID: "1", Payload: "test"})
+		require.NoError(t, err)
+
+		// Wait a moment for task to start processing
+		time.Sleep(500 * time.Millisecond)
+
+		// Try to stop with a short timeout
+		stopCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		err = jq.Stop(stopCtx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "stop timeout")
+
+		// Clean up
+		close(blockForever)
+	})
+}
+
+func TestJobQueue_Stop_MultipleCallsHandled(t *testing.T) {
+	t.Run("handles multiple Stop calls gracefully", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil)
+
+		// Register a simple task
+		err := jq.Register("simple-task", func(ctx context.Context, msg TestMessage) error {
+			time.Sleep(50 * time.Millisecond)
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Start the queue
+		ctx := context.Background()
+		jq.Start(ctx)
+
+		// Call Stop multiple times concurrently
+		var wg sync.WaitGroup
+		errs := make([]error, 3)
+
+		for i := 0; i < 3; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				defer cancel()
+				errs[idx] = jq.Stop(stopCtx)
+			}(i)
+		}
+
+		wg.Wait()
+
+		// First call should succeed, others should get "already stopping" error
+		successCount := 0
+		alreadyStoppingCount := 0
+
+		for _, err := range errs {
+			if err == nil {
+				successCount++
+			} else if err.Error() == "job queue is already stopping" {
+				alreadyStoppingCount++
+			}
+		}
+
+		require.Equal(t, 1, successCount, "exactly one Stop call should succeed")
+		require.Equal(t, 2, alreadyStoppingCount, "other Stop calls should get 'already stopping' error")
+	})
+}
+
+func TestJobQueue_Stop_CompletesAllPendingTasks(t *testing.T) {
+	t.Run("processes all tasks before shutdown", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil, jobqueue.WithMaxWorkers(2))
+
+		var processedCount atomic.Int32
+		taskProcessing := make(chan struct{}, 10)
+
+		// Register a task that tracks processing
+		err := jq.Register("count-task", func(ctx context.Context, msg TestMessage) error {
+			taskProcessing <- struct{}{}
+			time.Sleep(50 * time.Millisecond) // Simulate work
+			processedCount.Add(1)
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Start the queue
+		ctx := context.Background()
+		jq.Start(ctx)
+
+		// Enqueue multiple tasks
+		expectedTasks := 5
+		for i := 0; i < expectedTasks; i++ {
+			err = jq.Enqueue(ctx, "count-task", TestMessage{
+				ID:      string(rune('0' + i)),
+				Payload: "test",
+			})
+			require.NoError(t, err)
+		}
+
+		// Wait for all tasks to be picked up and start processing
+		for i := 0; i < expectedTasks; i++ {
+			select {
+			case <-taskProcessing:
+				// Task started
+			case <-time.After(2 * time.Second):
+				t.Fatalf("Only %d tasks started out of %d", i, expectedTasks)
+			}
+		}
+
+		// Stop the queue
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		err = jq.Stop(stopCtx)
+		require.NoError(t, err)
+
+		// Verify all enqueued tasks were processed
+		require.Equal(t, int32(expectedTasks), processedCount.Load())
+	})
+}
+
+func TestJobQueue_Stop_EnqueueDuringShutdown(t *testing.T) {
+	t.Run("rejects new tasks during shutdown", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil, jobqueue.WithMaxWorkers(1))
+
+		shutdownStarted := make(chan struct{})
+		taskCanComplete := make(chan struct{})
+
+		// Register a task that signals when running
+		err := jq.Register("slow-task", func(ctx context.Context, msg TestMessage) error {
+			close(shutdownStarted)
+			<-taskCanComplete
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Start the queue
+		ctx := context.Background()
+		jq.Start(ctx)
+
+		// Enqueue a task
+		err = jq.Enqueue(ctx, "slow-task", TestMessage{ID: "1", Payload: "test"})
+		require.NoError(t, err)
+
+		// Wait for task to start
+		<-shutdownStarted
+
+		// Start stopping in a goroutine
+		stopDone := make(chan error, 1)
+		go func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			stopDone <- jq.Stop(stopCtx)
+		}()
+
+		// Give Stop a moment to mark as stopping
+		time.Sleep(200 * time.Millisecond)
+
+		// Try to enqueue during shutdown
+		err = jq.Enqueue(ctx, "slow-task", TestMessage{ID: "2", Payload: "test"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "job queue is stopping")
+
+		// Complete the running task
+		close(taskCanComplete)
+
+		// Wait for Stop to complete
+		select {
+		case err := <-stopDone:
+			require.NoError(t, err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("Stop did not complete")
+		}
+	})
+}
+
+func TestJobQueue_Stop_WithoutStart(t *testing.T) {
+	t.Run("can stop without starting", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil)
+
+		// Stop without starting
+		stopCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		err := jq.Stop(stopCtx)
+		require.NoError(t, err)
+
+		// Should not be able to enqueue
+		ctx := context.Background()
+		err = jq.Enqueue(ctx, "test", TestMessage{ID: "1", Payload: "test"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "job queue is stopping")
+	})
+}
+
+func TestJobQueue_Stop_TaskFailureHandling(t *testing.T) {
+	t.Run("completes shutdown even if tasks fail", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil,
+			jobqueue.WithMaxWorkers(2))
+
+		var processedCount atomic.Int32
+
+		// Register tasks that fail
+		err := jq.Register("failing-task", func(ctx context.Context, msg TestMessage) error {
+			processedCount.Add(1)
+			return errors.New("task failed")
+		})
+		require.NoError(t, err)
+
+		// Start the queue
+		ctx := context.Background()
+		jq.Start(ctx)
+
+		// Enqueue multiple tasks that will fail
+		for i := 0; i < 3; i++ {
+			err = jq.Enqueue(ctx, "failing-task", TestMessage{
+				ID:      string(rune('0' + i)),
+				Payload: "test",
+			})
+			require.NoError(t, err)
+		}
+
+		// Give tasks time to be processed
+		time.Sleep(500 * time.Millisecond)
+
+		// Stop should complete successfully even though tasks failed
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		err = jq.Stop(stopCtx)
+		require.NoError(t, err)
+
+		// Verify tasks were attempted
+		require.GreaterOrEqual(t, processedCount.Load(), int32(3))
+	})
+}
+
+func TestJobQueue_StartStopStartCycle(t *testing.T) {
+	t.Run("can restart after stop", func(t *testing.T) {
+		jq := newTestJobQueue(t, nil)
+
+		var processedCount atomic.Int32
+
+		// Register a simple task
+		err := jq.Register("simple-task", func(ctx context.Context, msg TestMessage) error {
+			processedCount.Add(1)
+			return nil
+		})
+		require.NoError(t, err)
+
+		// First cycle: Start, enqueue, stop
+		ctx := context.Background()
+		jq.Start(ctx)
+
+		err = jq.Enqueue(ctx, "simple-task", TestMessage{ID: "1", Payload: "first"})
+		require.NoError(t, err)
+
+		time.Sleep(300 * time.Millisecond) // Let task process
+
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		err = jq.Stop(stopCtx)
+		cancel()
+		require.NoError(t, err)
+
+		require.Equal(t, int32(1), processedCount.Load())
+
+		// Note: In the current implementation, we cannot restart after Stop
+		// because stopping is permanent. This test documents this behavior.
+		// If restart capability is needed, the JobQueue struct would need
+		// to reset the stopping flag in Start() method.
+
+		// Try to start again - this will be a no-op due to stopping flag
+		jq.Start(ctx)
+
+		// Enqueue will fail because queue is still marked as stopping
+		err = jq.Enqueue(ctx, "simple-task", TestMessage{ID: "2", Payload: "second"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "job queue is stopping")
+	})
+}

--- a/pkg/pdp/aggregator/jobqueue/worker/worker.go
+++ b/pkg/pdp/aggregator/jobqueue/worker/worker.go
@@ -131,6 +131,7 @@ func WithOnFailure[T any](onFailure OnFailureFn[T]) JobOption[T] {
 	}
 }
 
+// Register must be called before `Start`
 func (r *Worker[T]) Register(name string, fn JobFn[T], opts ...JobOption[T]) error {
 	if _, ok := r.jobs[name]; ok {
 		return fmt.Errorf(`job "%v" already registered`, name)

--- a/pkg/pdp/aggregator/jobqueue/worker/worker.go
+++ b/pkg/pdp/aggregator/jobqueue/worker/worker.go
@@ -125,6 +125,7 @@ func (r *Worker[T]) Start(ctx context.Context) {
 type JobOption[T any] func(*jobRegistration[T])
 
 // WithOnFailure sets a callback to be invoked only when the job fails after max retries
+// The Worker only supports a single OnFailure callback for a job, multiple OnFailure options must not be provided.
 func WithOnFailure[T any](onFailure OnFailureFn[T]) JobOption[T] {
 	return func(jr *jobRegistration[T]) {
 		jr.onFailure = onFailure

--- a/pkg/pdp/aggregator/local.go
+++ b/pkg/pdp/aggregator/local.go
@@ -49,8 +49,12 @@ type LocalAggregator struct {
 
 // Startup starts up aggregation queues
 func (la *LocalAggregator) Startup(ctx context.Context) error {
-	go la.pieceQueue.Start(ctx)
-	go la.linkQueue.Start(ctx)
+	if err := la.pieceQueue.Start(ctx); err != nil {
+		return err
+	}
+	if err := la.linkQueue.Start(ctx); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/service/replicator/replicate.go
+++ b/pkg/service/replicator/replicate.go
@@ -2,23 +2,17 @@ package replicator
 
 import (
 	"context"
-	"database/sql"
-	"runtime"
 
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/storacha/go-ucanto/client"
 	"github.com/storacha/go-ucanto/principal"
 
 	"github.com/storacha/piri/pkg/pdp"
 	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue"
-	"github.com/storacha/piri/pkg/pdp/aggregator/jobqueue/serializer"
 	"github.com/storacha/piri/pkg/service/blobs"
 	"github.com/storacha/piri/pkg/service/claims"
 	replicahandler "github.com/storacha/piri/pkg/service/storage/handlers/replica"
 	"github.com/storacha/piri/pkg/store/receiptstore"
 )
-
-var log = logging.Logger("replicator")
 
 type Replicator interface {
 	Replicate(context.Context, *replicahandler.TransferRequest) error
@@ -26,7 +20,7 @@ type Replicator interface {
 
 type Service struct {
 	queue   *jobqueue.JobQueue[*replicahandler.TransferRequest]
-	queueDB *sql.DB
+	adapter *adapter
 }
 
 type adapter struct {
@@ -52,46 +46,27 @@ func New(
 	c claims.Claims,
 	rstore receiptstore.ReceiptStore,
 	uploadConn client.Connection,
-	db *sql.DB,
+	queue *jobqueue.JobQueue[*replicahandler.TransferRequest],
 ) (*Service, error) {
-
-	replicationQueue, err := jobqueue.New[*replicahandler.TransferRequest](
-		"replication",
-		db,
-		&serializer.JSON[*replicahandler.TransferRequest]{},
-		jobqueue.WithLogger(log.With("queue", "replication")),
-		jobqueue.WithMaxRetries(10),
-		jobqueue.WithMaxWorkers(uint(runtime.NumCPU())),
-	)
-	if err != nil {
-		return nil, err
-	}
-	if err := replicationQueue.Register("transfer-task", func(ctx context.Context, request *replicahandler.TransferRequest) error {
-		return replicahandler.Transfer(ctx,
-			&adapter{
-				id:         id,
-				pdp:        p,
-				blobs:      b,
-				claims:     c,
-				receipts:   rstore,
-				uploadConn: uploadConn,
-			},
-			request)
-	}); err != nil {
-		return nil, err
-	}
-	return &Service{queue: replicationQueue, queueDB: db}, nil
+	return &Service{
+		queue: queue,
+		adapter: &adapter{
+			id:         id,
+			pdp:        p,
+			blobs:      b,
+			claims:     c,
+			receipts:   rstore,
+			uploadConn: uploadConn,
+		},
+	}, nil
 }
 
 func (r *Service) Replicate(ctx context.Context, task *replicahandler.TransferRequest) error {
 	return r.queue.Enqueue(ctx, "transfer-task", task)
 }
 
-func (r *Service) Start(ctx context.Context) error {
-	go r.queue.Start(ctx)
-	return nil
-}
-
-func (r *Service) Stop(_ context.Context) error {
-	return r.queueDB.Close()
+func (r *Service) RegisterTransferTask(queue *jobqueue.JobQueue[*replicahandler.TransferRequest]) error {
+	return queue.Register("transfer-task", func(ctx context.Context, request *replicahandler.TransferRequest) error {
+		return replicahandler.Transfer(ctx, r.adapter, request)
+	})
 }

--- a/pkg/service/storage/service.go
+++ b/pkg/service/storage/service.go
@@ -284,8 +284,7 @@ func New(opts ...Option) (*StorageService, error) {
 	var queueCancel context.CancelFunc
 	startFuncs = append(startFuncs, func(ctx context.Context) error {
 		queueCtx, queueCancel = context.WithCancel(context.Background())
-		replicationQueue.Start(queueCtx)
-		return nil
+		return replicationQueue.Start(queueCtx)
 	})
 	closeFuncs = append(closeFuncs, func(ctx context.Context) error {
 		if queueCancel != nil {

--- a/pkg/service/storage/service.go
+++ b/pkg/service/storage/service.go
@@ -284,7 +284,7 @@ func New(opts ...Option) (*StorageService, error) {
 	var queueCancel context.CancelFunc
 	startFuncs = append(startFuncs, func(ctx context.Context) error {
 		queueCtx, queueCancel = context.WithCancel(context.Background())
-		go replicationQueue.Start(queueCtx)
+		replicationQueue.Start(queueCtx)
 		return nil
 	})
 	closeFuncs = append(closeFuncs, func(ctx context.Context) error {


### PR DESCRIPTION
# What
This change does two thing:
1. Implements graceful shutdown the of the jobqueue, blocking stop calls until all active jobs complete of the stop context is cancel, while preventing new jobs from being added during shutdown
2. Implements an OnFailure option in the Job queue that is called when a job exhausts all its retries, this is useful for addressing https://github.com/storacha/piri/issues/215 - specifically the case mentioned here: https://github.com/storacha/piri/pull/216#issuecomment-3253326999