### PR TITLE
fix: replica transfer conclude invocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/storacha/delegator v0.0.2-0.20250826191448-ba8d497e162a
 	github.com/storacha/go-libstoracha v0.2.2
-	github.com/storacha/go-ucanto v0.6.0
+	github.com/storacha/go-ucanto v0.6.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.37.0

--- a/go.sum
+++ b/go.sum
@@ -1682,6 +1682,8 @@ github.com/storacha/go-libstoracha v0.2.2 h1:PWzjdUfdcsd2qmN+HKpGyZu1tQXRY1F4zdl
 github.com/storacha/go-libstoracha v0.2.2/go.mod h1:zzeqIZhBBuWR2dkGygYqv4Bhg3JsvHuuvDCcdXCwGhg=
 github.com/storacha/go-ucanto v0.6.0 h1:6jiLO2fdfgAu5uyGl435o4pqqN8aQQgacnGLw+m1zAs=
 github.com/storacha/go-ucanto v0.6.0/go.mod h1:O35Ze4x18EWtz3ftRXXd/mTZ+b8OQVjYYrnadJ/xNjg=
+github.com/storacha/go-ucanto v0.6.1 h1:aHDIR18nf6XI6VWsFmTG78FDCzNPgMwGIYJUW5DA2yY=
+github.com/storacha/go-ucanto v0.6.1/go.mod h1:O35Ze4x18EWtz3ftRXXd/mTZ+b8OQVjYYrnadJ/xNjg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/service/storage/ucan_test.go
+++ b/pkg/service/storage/ucan_test.go
@@ -471,9 +471,10 @@ func TestReplicaAllocateTransfer(t *testing.T) {
 			// "Wait" for the transfer invocation to produce a receipt
 			// simulating the upload-service getting a receipt from this storage node.
 			ucanConcludeMsg := mustWaitForTransferMsg(t, ctx, transferOkChan)
-			// expect one invocation and one receipt
+			// expect one invocation and 0 receipts
 			require.Len(t, ucanConcludeMsg.Invocations(), 1)
-			require.Len(t, ucanConcludeMsg.Receipts(), 1)
+			// receipt is attached to the invocation, not a reciept in the message
+			require.Len(t, ucanConcludeMsg.Receipts(), 0)
 
 			// Full read + assertion on the transfer invocation and its ucan chain
 			mustAssertTransferInvocation(


### PR DESCRIPTION
This fixes the invocation made to the upload service to communicate the completion of the `blob/replica/transfer` task.

We use `client.Execute(...)` to make a `ucan/conclude` invocation instead of hand rolling and sending an agent message.

This also adds code to inspect the receipt for a failure. Since the UCAN service is RPC style, it will still return a HTTP 200 even if the receipt contains an error message. So where previously this would have succeeded if the upload service sent an failure receipt, it will now fail.

fixes https://github.com/storacha/piri/issues/234