### PR TITLE
feat: fetch egress tracking proof on init

### DIFF
--- a/cmd/cli/serve/full.go
+++ b/cmd/cli/serve/full.go
@@ -75,6 +75,29 @@ func init() {
 	cobra.CheckErr(viper.BindEnv("ucan.services.indexer.url", "PIRI_INDEXING_SERVICE_URL"))
 
 	FullCmd.Flags().String(
+		"egress-tracking-service-proof",
+		"",
+		"A delegation that allows the node to track egress with the egress tracking service",
+	)
+	cobra.CheckErr(viper.BindPFlag("ucan.services.etracker.proof", FullCmd.Flags().Lookup("egress-tracking-service-proof")))
+
+	FullCmd.Flags().String(
+		"egress-tracking-service-did",
+		presets.EgressTrackingServiceDID.String(),
+		"DID of the egress tracking service",
+	)
+	cobra.CheckErr(FullCmd.Flags().MarkHidden("egress-tracking-service-did"))
+	cobra.CheckErr(viper.BindPFlag("ucan.services.etracker.did", FullCmd.Flags().Lookup("egress-tracking-service-did")))
+
+	FullCmd.Flags().String(
+		"egress-tracking-service-url",
+		presets.EgressTrackingServiceURL.String(),
+		"URL of the egress tracking service",
+	)
+	cobra.CheckErr(FullCmd.Flags().MarkHidden("egress-tracking-service-url"))
+	cobra.CheckErr(viper.BindPFlag("ucan.services.etracker.url", FullCmd.Flags().Lookup("egress-tracking-service-url")))
+
+	FullCmd.Flags().String(
 		"upload-service-did",
 		presets.UploadServiceDID.String(),
 		"DID of the upload service",

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -45,6 +45,8 @@ The configuration file uses TOML format with these parts:
 	[ucan.services]
 		[ucan.services.indexer]
 			proof = "mAYIEA..."
+		[ucan.services.etracker]
+			proof = "mAYIEA..."
 ```
 
 ### Configuration Sections

--- a/pkg/config/app/services.go
+++ b/pkg/config/app/services.go
@@ -11,14 +11,20 @@ import (
 type ExternalServicesConfig struct {
 	PrincipalMapping map[string]string
 
-	Indexer   IndexingServiceConfig
-	Upload    UploadServiceConfig
-	Publisher PublisherServiceConfig
+	Indexer       IndexingServiceConfig
+	EgressTracker EgressTrackingServiceConfig
+	Upload        UploadServiceConfig
+	Publisher     PublisherServiceConfig
 }
 
 // IndexingServiceConfig contains indexing service connection and proof(s) for
 // using the service
 type IndexingServiceConfig struct {
+	Connection client.Connection
+	Proofs     delegation.Proofs
+}
+
+type EgressTrackingServiceConfig struct {
 	Connection client.Connection
 	Proofs     delegation.Proofs
 }

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -17,9 +17,10 @@ import (
 type ServicesConfig struct {
 	ServicePrincipalMapping map[string]string `mapstructure:"principal_mapping" flag:"service-principal-mapping" toml:"principal_mapping,omitempty"`
 
-	Indexer   IndexingServiceConfig  `mapstructure:"indexer" validate:"required" toml:"indexer,omitempty"`
-	Upload    UploadServiceConfig    `mapstructure:"upload" validate:"required" toml:"upload,omitempty"`
-	Publisher PublisherServiceConfig `mapstructure:"publisher" validate:"required" toml:"publisher,omitempty"`
+	Indexer       IndexingServiceConfig       `mapstructure:"indexer" validate:"required" toml:"indexer,omitempty"`
+	EgressTracker EgressTrackingServiceConfig `mapstructure:"etracker" validate:"required" toml:"etracker,omitempty"`
+	Upload        UploadServiceConfig         `mapstructure:"upload" validate:"required" toml:"upload,omitempty"`
+	Publisher     PublisherServiceConfig      `mapstructure:"publisher" validate:"required" toml:"publisher,omitempty"`
 }
 
 func (s ServicesConfig) Validate() error {
@@ -39,6 +40,10 @@ func (s ServicesConfig) ToAppConfig(publicURL url.URL) (app.ExternalServicesConf
 	out.Indexer, err = s.Indexer.ToAppConfig()
 	if err != nil {
 		return app.ExternalServicesConfig{}, fmt.Errorf("creating indexing service app config: %w", err)
+	}
+	out.EgressTracker, err = s.EgressTracker.ToAppConfig()
+	if err != nil {
+		return app.ExternalServicesConfig{}, fmt.Errorf("creating egress tracking service app config: %w", err)
 	}
 
 	out.Publisher, err = s.Publisher.ToAppConfig(publicURL)
@@ -97,6 +102,52 @@ func (s *IndexingServiceConfig) ToAppConfig() (app.IndexingServiceConfig, error)
 		//   2. Return an app config with a nil indexing service connection
 		//      dependencies of this config are usually fine with a nil connection, as they check it before use.
 		log.Warn("no indexing service proof provided, indexing will likely fail, please provide indexing proof")
+	}
+	return out, nil
+}
+
+type EgressTrackingServiceConfig struct {
+	DID   string `mapstructure:"did" validate:"required" flag:"egress-tracking-service-did" toml:"did,omitempty"`
+	URL   string `mapstructure:"url" validate:"required,url" flag:"egress-tracking-service-url" toml:"url,omitempty"`
+	Proof string `mapstructure:"proof" flag:"egress-tracking-service-proof" toml:"proof,omitempty"`
+}
+
+func (c *EgressTrackingServiceConfig) Validate() error {
+	return validateConfig(c)
+}
+
+func (c *EgressTrackingServiceConfig) ToAppConfig() (app.EgressTrackingServiceConfig, error) {
+	sdid, err := did.Parse(c.DID)
+	if err != nil {
+		return app.EgressTrackingServiceConfig{}, fmt.Errorf("parsing egress tracking service DID: %w", err)
+	}
+	surl, err := url.Parse(c.URL)
+	if err != nil {
+		return app.EgressTrackingServiceConfig{}, fmt.Errorf("parsing egress tracking service URL: %w", err)
+	}
+	schannel := ucanhttp.NewHTTPChannel(surl)
+	sconn, err := client.NewConnection(sdid, schannel)
+	if err != nil {
+		return app.EgressTrackingServiceConfig{}, fmt.Errorf("creating egress tracking service connection: %w", err)
+	}
+	out := app.EgressTrackingServiceConfig{
+		Connection: sconn,
+	}
+	// Parse egress tracking service proofs if provided
+	if c.Proof != "" {
+		dlg, err := delegation.Parse(c.Proof)
+		if err != nil {
+			return app.EgressTrackingServiceConfig{}, fmt.Errorf("parsing egress tracking service proof: %w", err)
+		}
+		out.Proofs = delegation.Proofs{delegation.FromDelegation(dlg)}
+	} else {
+		// TODO(forrest): in the event a node is run without an egress tracking service proof, it will
+		// almost always fail to track egress...obviously.
+		// The TODO here is one of:
+		//   1. Fail to start the node (will be annoying for testing
+		//   2. Return an app config with a nil egress tracking service connection
+		//      dependencies of this config are usually fine with a nil connection, as they check it before use.
+		log.Warn("no egress tracking service proof provided, egress tracking will likely fail, please provide egress tracking proof")
 	}
 	return out, nil
 }

--- a/pkg/presets/presets.go
+++ b/pkg/presets/presets.go
@@ -9,12 +9,14 @@ import (
 )
 
 var (
-	IPNIAnnounceURLs   []url.URL
-	IndexingServiceDID did.DID
-	IndexingServiceURL *url.URL
-	UploadServiceURL   *url.URL
-	UploadServiceDID   did.DID
-	PrincipalMapping   map[string]string
+	IPNIAnnounceURLs         []url.URL
+	IndexingServiceDID       did.DID
+	IndexingServiceURL       *url.URL
+	EgressTrackingServiceDID did.DID
+	EgressTrackingServiceURL *url.URL
+	UploadServiceURL         *url.URL
+	UploadServiceDID         did.DID
+	PrincipalMapping         map[string]string
 )
 
 var (
@@ -36,6 +38,8 @@ func init() {
 		IPNIAnnounceURLs = prodIPNIAnnounceURLs
 		IndexingServiceURL = prodIndexingServiceURL
 		IndexingServiceDID = prodIndexingServiceDID
+		EgressTrackingServiceURL = prodEgressTrackingServiceURL
+		EgressTrackingServiceDID = prodEgressTrackingServiceDID
 		UploadServiceURL = prodUploadServiceURL
 		UploadServiceDID = prodUploadServiceDID
 		PrincipalMapping = prodPrincipalMapping
@@ -43,6 +47,8 @@ func init() {
 		IPNIAnnounceURLs = stagingIPNIAnnounceURLs
 		IndexingServiceURL = stagingIndexingServiceURL
 		IndexingServiceDID = stagingIndexingServiceDID
+		EgressTrackingServiceURL = stagingEgressTrackingServiceURL
+		EgressTrackingServiceDID = stagingEgressTrackingServiceDID
 		UploadServiceURL = stagingUploadServiceURL
 		UploadServiceDID = stagingUploadServiceDID
 		PrincipalMapping = stagingPrincipalMapping
@@ -50,6 +56,8 @@ func init() {
 		IPNIAnnounceURLs = warmStageIPNIAnnounceURLs
 		IndexingServiceURL = warmStageIndexingServiceURL
 		IndexingServiceDID = warmStageIndexingServiceDID
+		EgressTrackingServiceURL = warmStageEgressTrackingServiceURL
+		EgressTrackingServiceDID = warmStageEgressTrackingServiceDID
 		UploadServiceURL = warmStageUploadServiceURL
 		UploadServiceDID = warmStageUploadServiceDID
 		PrincipalMapping = warmStagePrincipalMapping
@@ -64,12 +72,16 @@ var (
 	warmStageIndexingServiceURL = lo.Must(url.Parse("https://staging.indexer.warm.storacha.network/claims"))
 	warmStageIndexingServiceDID = lo.Must(did.Parse("did:web:staging.indexer.warm.storacha.network"))
 
+	warmStageEgressTrackingServiceURL = lo.Must(url.Parse("https://staging.etracker.warm.storacha.network"))
+	warmStageEgressTrackingServiceDID = lo.Must(did.Parse("did:web:staging.etracker.warm.storacha.network"))
+
 	warmStageUploadServiceURL = lo.Must(url.Parse("https://staging.up.warm.storacha.network"))
 	warmStageUploadServiceDID = lo.Must(did.Parse("did:web:staging.up.warm.storacha.network"))
 
 	warmStagePrincipalMapping = map[string]string{
-		warmStageUploadServiceDID.String():   "did:key:z6MkpR58oZpK7L3cdZZciKT25ynGro7RZm6boFouWQ7AzF7v",
-		warmStageIndexingServiceDID.String(): "did:key:z6Mkr4QkdinnXQmJ9JdnzwhcEjR8nMnuVPEwREyh9jp2Pb7k",
+		warmStageUploadServiceDID.String():         "did:key:z6MkpR58oZpK7L3cdZZciKT25ynGro7RZm6boFouWQ7AzF7v",
+		warmStageIndexingServiceDID.String():       "did:key:z6Mkr4QkdinnXQmJ9JdnzwhcEjR8nMnuVPEwREyh9jp2Pb7k",
+		warmStageEgressTrackingServiceDID.String(): "did:key:z6Mkqv9fjGQpNKQdgUxkq2VYH2nKiKZiGPxbtYjhJBz8wfAn",
 	}
 )
 
@@ -81,11 +93,16 @@ var (
 	stagingIndexingServiceURL = lo.Must(url.Parse("https://staging.indexer.storacha.network/claims"))
 	stagingIndexingServiceDID = lo.Must(did.Parse("did:web:staging.indexer.storacha.network"))
 
+	stagingEgressTrackingServiceURL = lo.Must(url.Parse("https://staging.etracker.storacha.network"))
+	stagingEgressTrackingServiceDID = lo.Must(did.Parse("did:web:staging.etracker.storacha.network"))
+
 	stagingUploadServiceURL = lo.Must(url.Parse("https://staging.up.storacha.network"))
 	stagingUploadServiceDID = lo.Must(did.Parse("did:web:staging.up.storacha.network"))
 
 	stagingPrincipalMapping = map[string]string{
-		stagingUploadServiceDID.String(): "did:key:z6MkhcbEpJpEvNVDd3n5RurquVdqs5dPU16JDU5VZTDtFgnn",
+		stagingUploadServiceDID.String():         "did:key:z6MkhcbEpJpEvNVDd3n5RurquVdqs5dPU16JDU5VZTDtFgnn",
+		stagingIndexingServiceDID.String():       "did:key:z6MkszJLAZ1tCHUTfDMKj9srMYA9zzLiPeMXijvmeECUScTZ",
+		stagingEgressTrackingServiceDID.String(): "did:key:z6MkmSQ8ZZQffBaQo5mr3fArRsDxKPXyPQFroiB1H9EbAHod",
 	}
 )
 
@@ -97,10 +114,15 @@ var (
 	prodIndexingServiceURL = lo.Must(url.Parse("https://indexer.storacha.network/claims"))
 	prodIndexingServiceDID = lo.Must(did.Parse("did:web:indexer.storacha.network"))
 
+	prodEgressTrackingServiceURL = lo.Must(url.Parse("https://etracker.storacha.network"))
+	prodEgressTrackingServiceDID = lo.Must(did.Parse("did:web:etracker.storacha.network"))
+
 	prodUploadServiceURL = lo.Must(url.Parse("https://up.storacha.network"))
 	prodUploadServiceDID = lo.Must(did.Parse("did:web:up.storacha.network"))
 
 	prodPrincipalMapping = map[string]string{
-		prodUploadServiceDID.String(): "did:key:z6MkqdncRZ1wj8zxCTDUQ8CRT8NQWd63T7mZRvZUX8B7XDFi",
+		prodUploadServiceDID.String():         "did:key:z6MkqdncRZ1wj8zxCTDUQ8CRT8NQWd63T7mZRvZUX8B7XDFi",
+		prodIndexingServiceDID.String():       "did:key:z6MkqMSJxrjzvpqmP3kZhk7eCasBK6DX1jaVaG7wD72LYRm7",
+		prodEgressTrackingServiceDID.String(): "did:key:z6MkiVMkL8MSzqi3iqFj2AjofQfL8wH6p7AcB2w34mKbyWfF",
 	}
 )


### PR DESCRIPTION
This PR depends on https://github.com/storacha/delegator/pull/11. It adds config and flags for the egress tracking service and uses the new delegator client method `RequestProofs` to fetch the delegation to invoke `space/egress/track` on the egress tracking service, along with the previous one to `claim/cache` on the indexer.