### PR TITLE
Fast follows to piri auto update

### DIFF
--- a/cmd/cli/setup/config.go
+++ b/cmd/cli/setup/config.go
@@ -8,33 +8,35 @@ import (
 
 // PathConfig holds all path-related configuration
 type PathConfig struct {
-	OptDir           string        // Base directory for piri installation
-	BinaryBaseDir    string        // Base directory for all versioned binaries
-	CurrentSymlink   string        // Symlink that points to the current version
-	BinaryPath       string        // Path to the current piri binary via symlink
-	SystemDir        string        // System configuration directory (not versioned)
-	SystemdDir       string        // Directory where systemd service files are stored
-	CLISymlinkPath   string        // Location of piri symlink in PATH
-	SystemdPath      string        // Directory where systemd service files are installed
-	SudoersFile      string        // Sudoers configuration file path
-	ConfigFileName   string        // Default config file name
-	ServerShutdown   time.Duration // Server shutdown timeout
-	SystemdBuffer    time.Duration // Additional systemd shutdown buffer
+	OptDir                string        // Base directory for piri installation
+	BinaryBaseDir         string        // Base directory for all versioned binaries
+	CurrentSymlink        string        // Symlink that points to the current version
+	BinaryPath            string        // Path to the current piri binary via symlink
+	SystemDir             string        // System configuration directory (not versioned)
+	SystemdBaseDir        string        // Base directory for versioned systemd files
+	SystemdCurrentSymlink string        // Symlink to current systemd version
+	CLISymlinkPath        string        // Location of piri symlink in PATH
+	SystemdPath           string        // /etc/systemd/system - where systemd reads from
+	SudoersFile           string        // Sudoers configuration file path
+	ConfigFileName        string        // Default config file name
+	ServerShutdown        time.Duration // Server shutdown timeout
+	SystemdBuffer         time.Duration // Additional systemd shutdown buffer
 }
 
 // DefaultPathConfig returns the default path configuration
 func DefaultPathConfig() *PathConfig {
 	return &PathConfig{
-		OptDir:         "/opt/piri",
-		BinaryBaseDir:  "/opt/piri/bin",
-		CurrentSymlink: "/opt/piri/bin/current",
-		BinaryPath:     "/opt/piri/bin/current/piri",
-		SystemDir:      "/opt/piri/etc",
-		SystemdDir:     "/opt/piri/systemd",
-		CLISymlinkPath: "/usr/local/bin/piri",
-		SystemdPath:    "/etc/systemd/system",
-		SudoersFile:    "/etc/sudoers.d/piri-updater",
-		ConfigFileName: "piri-config.toml",
+		OptDir:                "/opt/piri",
+		BinaryBaseDir:         "/opt/piri/bin",
+		CurrentSymlink:        "/opt/piri/bin/current",
+		BinaryPath:            "/opt/piri/bin/current/piri",
+		SystemDir:             "/opt/piri/etc",
+		SystemdBaseDir:        "/opt/piri/systemd",
+		SystemdCurrentSymlink: "/opt/piri/systemd/current",
+		CLISymlinkPath:        "/usr/local/bin/piri",
+		SystemdPath:           "/etc/systemd/system",
+		SudoersFile:           "/etc/sudoers.d/piri-updater",
+		ConfigFileName:        "piri-config.toml",
 		// PiriServerShutdownTimeout is the duration in which we expect piri server to shut down gracefully
 		// This timeout allows fx to wait up to one minute for all lifecycle shutdown hooks to execute.
 		ServerShutdown: time.Minute,
@@ -55,7 +57,9 @@ var (
 	PiriCurrentSymlink        = Config.CurrentSymlink
 	PiriBinaryPath            = Config.BinaryPath
 	PiriSystemDir             = Config.SystemDir
-	PiriSystemdDir            = Config.SystemdDir
+	PiriSystemdBaseDir        = Config.SystemdBaseDir
+	PiriSystemdCurrentSymlink = Config.SystemdCurrentSymlink
+	PiriSystemdDir            = Config.SystemdCurrentSymlink // Points to current version for backward compat
 )
 
 // getVersionedBinaryDir returns the versioned directory for a specific piri binary
@@ -70,6 +74,20 @@ func getVersionedBinaryDir(version string) string {
 		cleanVersion = "v" + cleanVersion
 	}
 	return filepath.Join(PiriBinaryBaseDir, cleanVersion)
+}
+
+// getVersionedSystemdDir returns the versioned directory for systemd service files
+func getVersionedSystemdDir(version string) string {
+	// Clean version string - remove any commit hash suffixes
+	cleanVersion := version
+	if idx := strings.Index(version, "-"); idx != -1 {
+		cleanVersion = version[:idx]
+	}
+	// Ensure version starts with 'v'
+	if !strings.HasPrefix(cleanVersion, "v") {
+		cleanVersion = "v" + cleanVersion
+	}
+	return filepath.Join(PiriSystemdBaseDir, cleanVersion)
 }
 
 // More compatibility constants

--- a/cmd/cli/setup/filesystem.go
+++ b/cmd/cli/setup/filesystem.go
@@ -43,13 +43,14 @@ func (fsm *FileSystemManager) CreatePiriDirectoryStructure(version string) error
 		return err
 	}
 
-	// Create config directory
-	if err := fsm.CreateDirectory(PiriSystemDir, 0755); err != nil {
+	// Create versioned systemd directory
+	versionedSystemdDir := getVersionedSystemdDir(version)
+	if err := fsm.CreateDirectory(versionedSystemdDir, 0755); err != nil {
 		return err
 	}
 
-	// Create systemd directory
-	if err := fsm.CreateDirectory(PiriSystemdDir, 0755); err != nil {
+	// Create config directory (not versioned - contains user config)
+	if err := fsm.CreateDirectory(PiriSystemDir, 0755); err != nil {
 		return err
 	}
 

--- a/cmd/cli/setup/filesystem_test.go
+++ b/cmd/cli/setup/filesystem_test.go
@@ -236,16 +236,18 @@ func TestFileSystemManager_CreatePiriDirectoryStructure(t *testing.T) {
 		PiriOptDir = Config.OptDir
 		PiriBinaryBaseDir = Config.BinaryBaseDir
 		PiriSystemDir = Config.SystemDir
-		PiriSystemdDir = Config.SystemdDir
+		PiriSystemdBaseDir = Config.SystemdBaseDir
+		PiriSystemdCurrentSymlink = Config.SystemdCurrentSymlink
 	}()
 
 	// Create test config with temp paths
 	tempDir := t.TempDir()
 	testConfig := &PathConfig{
-		OptDir:        tempDir,
-		BinaryBaseDir: filepath.Join(tempDir, "bin"),
-		SystemDir:     filepath.Join(tempDir, "etc"),
-		SystemdDir:    filepath.Join(tempDir, "systemd"),
+		OptDir:                tempDir,
+		BinaryBaseDir:         filepath.Join(tempDir, "bin"),
+		SystemDir:             filepath.Join(tempDir, "etc"),
+		SystemdBaseDir:        filepath.Join(tempDir, "systemd"),
+		SystemdCurrentSymlink: filepath.Join(tempDir, "systemd", "current"),
 	}
 
 	// Override global config
@@ -253,7 +255,8 @@ func TestFileSystemManager_CreatePiriDirectoryStructure(t *testing.T) {
 	PiriOptDir = testConfig.OptDir
 	PiriBinaryBaseDir = testConfig.BinaryBaseDir
 	PiriSystemDir = testConfig.SystemDir
-	PiriSystemdDir = testConfig.SystemdDir
+	PiriSystemdBaseDir = testConfig.SystemdBaseDir
+	PiriSystemdCurrentSymlink = testConfig.SystemdCurrentSymlink
 
 	fsm := NewFileSystemManager()
 	err := fsm.CreatePiriDirectoryStructure("v1.0.0")
@@ -262,7 +265,7 @@ func TestFileSystemManager_CreatePiriDirectoryStructure(t *testing.T) {
 	// Verify all directories were created
 	require.DirExists(t, filepath.Join(testConfig.BinaryBaseDir, "v1.0.0"))
 	require.DirExists(t, testConfig.SystemDir)
-	require.DirExists(t, testConfig.SystemdDir)
+	require.DirExists(t, filepath.Join(testConfig.SystemdBaseDir, "v1.0.0"))
 
 	// Verify they were tracked for rollback
 	require.Len(t, fsm.CreatedDirs, 3)

--- a/cmd/cli/setup/installer_test.go
+++ b/cmd/cli/setup/installer_test.go
@@ -19,7 +19,8 @@ func TestInstaller_GenerateSystemdServices(t *testing.T) {
 	require.NoError(t, err)
 
 	serviceUser := "testuser"
-	services := installer.GenerateSystemdServices(serviceUser)
+	version := "1.0.0"
+	services := installer.GenerateSystemdServices(serviceUser, version)
 
 	// Should generate 3 service files
 	require.Len(t, services, 3)
@@ -48,11 +49,12 @@ func TestInstaller_InstallBinary(t *testing.T) {
 	// Setup test environment with custom config
 	tempDir := t.TempDir()
 	testConfig := &PathConfig{
-		OptDir:         tempDir,
-		BinaryBaseDir:  filepath.Join(tempDir, "bin"),
-		CurrentSymlink: filepath.Join(tempDir, "bin", "current"),
-		SystemDir:      filepath.Join(tempDir, "etc"),
-		SystemdDir:     filepath.Join(tempDir, "systemd"),
+		OptDir:                tempDir,
+		BinaryBaseDir:         filepath.Join(tempDir, "bin"),
+		CurrentSymlink:        filepath.Join(tempDir, "bin", "current"),
+		SystemDir:             filepath.Join(tempDir, "etc"),
+		SystemdBaseDir:        filepath.Join(tempDir, "systemd"),
+		SystemdCurrentSymlink: filepath.Join(tempDir, "systemd", "current"),
 	}
 
 	// Save and override global config
@@ -62,14 +64,16 @@ func TestInstaller_InstallBinary(t *testing.T) {
 	PiriBinaryBaseDir = testConfig.BinaryBaseDir
 	PiriCurrentSymlink = testConfig.CurrentSymlink
 	PiriSystemDir = testConfig.SystemDir
-	PiriSystemdDir = testConfig.SystemdDir
+	PiriSystemdBaseDir = testConfig.SystemdBaseDir
+	PiriSystemdCurrentSymlink = testConfig.SystemdCurrentSymlink
 	defer func() {
 		Config = oldConfig
 		PiriOptDir = Config.OptDir
 		PiriBinaryBaseDir = Config.BinaryBaseDir
 		PiriCurrentSymlink = Config.CurrentSymlink
 		PiriSystemDir = Config.SystemDir
-		PiriSystemdDir = Config.SystemdDir
+		PiriSystemdBaseDir = Config.SystemdBaseDir
+		PiriSystemdCurrentSymlink = Config.SystemdCurrentSymlink
 	}()
 
 	installer, err := NewInstaller()

--- a/cmd/cli/setup/internal.go
+++ b/cmd/cli/setup/internal.go
@@ -195,7 +195,7 @@ func applyManagedUpdate(ctx context.Context, cmd *cobra.Command, release *GitHub
 	}
 
 	// Perform symlink update with rollback capability
-	oldTarget, rollbackFunc, err := fsm.UpdateSymlinkAtomic(
+	oldTarget, symlinkRollbackFunc, err := fsm.UpdateSymlinkAtomic(
 		PiriCurrentSymlink,
 		versionedBinDir,
 	)
@@ -211,6 +211,92 @@ func applyManagedUpdate(ctx context.Context, cmd *cobra.Command, release *GitHub
 			PiriCurrentSymlink, versionedBinDir)
 	}
 
-	// Return the rollback function for use if restart fails
+	// Create versioned systemd directory and write service files
+	installer, err := NewInstaller()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create installer: %w", err)
+	}
+
+	// Get the service user from platform
+	platform, err := NewPlatformChecker()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get platform info: %w", err)
+	}
+
+	// Create versioned systemd directory
+	versionedSystemdDir := getVersionedSystemdDir(newVersion)
+	if err := fsm.CreateDirectory(versionedSystemdDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create systemd directory: %w", err)
+	}
+
+	// Generate and write service files to the versioned directory
+	serviceFiles := installer.GenerateSystemdServices(platform.ServiceUser, newVersion)
+	for _, svc := range serviceFiles {
+		if err := fsm.WriteFile(svc.SourcePath, []byte(svc.Content), 0644); err != nil {
+			return nil, fmt.Errorf("failed to write service file %s: %w", svc.Name, err)
+		}
+	}
+
+	// Set ownership on systemd directory
+	if err := fsm.SetOwnershipFromPath(versionedSystemdDir, PiriOptDir); err != nil {
+		return nil, fmt.Errorf("failed to set ownership on systemd dir: %w", err)
+	}
+
+	// Update systemd symlink atomically
+	oldSystemdTarget, systemdRollbackFunc, err := fsm.UpdateSymlinkAtomic(
+		PiriSystemdCurrentSymlink,
+		versionedSystemdDir,
+	)
+	if err != nil {
+		// Rollback binary symlink and fail
+		_ = symlinkRollbackFunc()
+		return nil, fmt.Errorf("failed to update systemd symlink: %w", err)
+	}
+
+	if oldSystemdTarget != "" {
+		cmd.Printf("Updated systemd symlink %s -> %s (previous: %s)\n",
+			PiriSystemdCurrentSymlink, versionedSystemdDir, oldSystemdTarget)
+	} else {
+		cmd.Printf("Created systemd symlink %s -> %s\n",
+			PiriSystemdCurrentSymlink, versionedSystemdDir)
+	}
+
+	// Reload systemd daemon to pick up the new symlinks
+	sm := NewServiceManager("piri")
+	if err := sm.Executor.Run("sudo", "systemctl", "daemon-reload"); err != nil {
+		cmd.Printf("Warning: Failed to reload systemd daemon: %v\n", err)
+	}
+
+	// Create combined rollback function that handles both binary and systemd symlinks
+	rollbackFunc := func() error {
+		var errs error
+
+		// Rollback binary symlink
+		if err := symlinkRollbackFunc(); err != nil {
+			errs = fmt.Errorf("failed to rollback binary symlink: %w", err)
+		}
+
+		// Rollback systemd symlink
+		if err := systemdRollbackFunc(); err != nil {
+			if errs != nil {
+				errs = fmt.Errorf("%v; failed to rollback systemd symlink: %w", errs, err)
+			} else {
+				errs = fmt.Errorf("failed to rollback systemd symlink: %w", err)
+			}
+		}
+
+		// Reload systemd daemon after rollback
+		if err := sm.Executor.Run("sudo", "systemctl", "daemon-reload"); err != nil {
+			if errs != nil {
+				errs = fmt.Errorf("%v; failed to reload systemd after rollback: %w", errs, err)
+			} else {
+				errs = fmt.Errorf("failed to reload systemd after rollback: %w", err)
+			}
+		}
+
+		return errs
+	}
+
+	// Return the combined rollback function for use if restart fails
 	return rollbackFunc, nil
 }

--- a/cmd/cli/setup/service_manager.go
+++ b/cmd/cli/setup/service_manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -32,14 +33,14 @@ type ServiceManager struct {
 	// Services to manage
 	Services []string
 	// Command executor (can be mocked for testing)
-	executor CommandExecutor
+	Executor CommandExecutor
 }
 
 // NewServiceManager creates a new service manager
 func NewServiceManager(services ...string) *ServiceManager {
 	return &ServiceManager{
 		Services: services,
-		executor: &RealCommandExecutor{},
+		Executor: &RealCommandExecutor{},
 	}
 }
 
@@ -47,13 +48,13 @@ func NewServiceManager(services ...string) *ServiceManager {
 func NewServiceManagerWithExecutor(executor CommandExecutor, services ...string) *ServiceManager {
 	return &ServiceManager{
 		Services: services,
-		executor: executor,
+		Executor: executor,
 	}
 }
 
 // IsActive checks if a service is currently active
 func (sm *ServiceManager) IsActive(service string) (bool, error) {
-	output, err := sm.executor.Output("systemctl", "is-active", service)
+	output, err := sm.Executor.Output("systemctl", "is-active", service)
 	status := strings.TrimSpace(string(output))
 	return status == "active", err
 }
@@ -74,7 +75,7 @@ func (sm *ServiceManager) CheckServicesNotRunning() error {
 func (sm *ServiceManager) StopService(service string) error {
 	active, _ := sm.IsActive(service)
 	if active {
-		if err := sm.executor.Run("systemctl", "stop", service); err != nil {
+		if err := sm.Executor.Run("systemctl", "stop", service); err != nil {
 			return fmt.Errorf("failed to stop service %s: %w", service, err)
 		}
 	}
@@ -83,7 +84,7 @@ func (sm *ServiceManager) StopService(service string) error {
 
 // StartService starts a service
 func (sm *ServiceManager) StartService(service string) error {
-	if err := sm.executor.Run("systemctl", "start", service); err != nil {
+	if err := sm.Executor.Run("systemctl", "start", service); err != nil {
 		return fmt.Errorf("failed to start service %s: %w", service, err)
 	}
 	return nil
@@ -91,7 +92,7 @@ func (sm *ServiceManager) StartService(service string) error {
 
 // EnableService enables a service for auto-start
 func (sm *ServiceManager) EnableService(service string) error {
-	if err := sm.executor.Run("systemctl", "enable", service); err != nil {
+	if err := sm.Executor.Run("systemctl", "enable", service); err != nil {
 		return fmt.Errorf("failed to enable service %s: %w", service, err)
 	}
 	return nil
@@ -100,7 +101,7 @@ func (sm *ServiceManager) EnableService(service string) error {
 // DisableService disables a service from auto-start
 func (sm *ServiceManager) DisableService(service string) error {
 	// The disable command will succeed even if the service doesn't exist
-	if err := sm.executor.Run("systemctl", "disable", service); err != nil {
+	if err := sm.Executor.Run("systemctl", "disable", service); err != nil {
 		// Only return error if it's not "service not found"
 		if !strings.Contains(err.Error(), "exit status") {
 			return fmt.Errorf("failed to disable service %s: %w", service, err)
@@ -134,7 +135,7 @@ func (sm *ServiceManager) EnableAndStartService(service string) error {
 
 // RestartService restarts a service
 func (sm *ServiceManager) RestartService(service string) error {
-	if err := sm.executor.Run("systemctl", "restart", service); err != nil {
+	if err := sm.Executor.Run("systemctl", "restart", service); err != nil {
 		return fmt.Errorf("failed to restart service %s: %w", service, err)
 	}
 	return nil
@@ -142,7 +143,7 @@ func (sm *ServiceManager) RestartService(service string) error {
 
 // RestartServiceWithSudo restarts a service using sudo
 func (sm *ServiceManager) RestartServiceWithSudo(service string) error {
-	if err := sm.executor.Run("sudo", "systemctl", "restart", service); err != nil {
+	if err := sm.Executor.Run("sudo", "systemctl", "restart", service); err != nil {
 		return fmt.Errorf("failed to restart service with sudo: %w", err)
 	}
 	return nil
@@ -173,7 +174,7 @@ func (sm *ServiceManager) VerifyServiceRestart(service string, timeoutSec int, u
 		}
 
 		// Check for failure state
-		output, _ := sm.executor.Output("systemctl", "is-failed", service)
+		output, _ := sm.Executor.Output("systemctl", "is-failed", service)
 		if strings.TrimSpace(string(output)) == "failed" {
 			return fmt.Errorf("service failed to start")
 		}
@@ -187,7 +188,7 @@ func (sm *ServiceManager) VerifyServiceRestart(service string, timeoutSec int, u
 
 // ReloadDaemon reloads the systemd daemon configuration
 func (sm *ServiceManager) ReloadDaemon() error {
-	if err := sm.executor.Run("systemctl", "daemon-reload"); err != nil {
+	if err := sm.Executor.Run("systemctl", "daemon-reload"); err != nil {
 		return fmt.Errorf("failed to reload systemd daemon: %w", err)
 	}
 	return nil
@@ -223,29 +224,28 @@ func (sm *ServiceManager) GetServiceStatus(service string) (*ServiceStatus, erro
 	status.Running = active
 
 	// Check if enabled
-	output, _ := sm.executor.Output("systemctl", "is-enabled", service)
+	output, _ := sm.Executor.Output("systemctl", "is-enabled", service)
 	status.Enabled = strings.TrimSpace(string(output)) == "enabled"
 
 	// Check if failed
-	output, _ = sm.executor.Output("systemctl", "is-failed", service)
+	output, _ = sm.Executor.Output("systemctl", "is-failed", service)
 	status.Failed = strings.TrimSpace(string(output)) == "failed"
 
 	return status, nil
 }
 
-// InstallServiceFiles writes service files and creates symlinks
+// InstallServiceFiles creates symlinks to the current version of service files
 func (sm *ServiceManager) InstallServiceFiles(services []ServiceFile) error {
 	for _, svc := range services {
-		servicePath := svc.SourcePath
+		// The source path should now point through the current symlink
+		currentServicePath := filepath.Join(PiriSystemdCurrentSymlink, filepath.Base(svc.SourcePath))
 		symlinkPath := svc.TargetPath
 
-		// Write the service file
-		if err := os.WriteFile(servicePath, []byte(svc.Content), 0644); err != nil {
-			return fmt.Errorf("failed to write %s: %w", svc.Name, err)
-		}
+		// Remove existing symlink if it exists
+		_ = os.Remove(symlinkPath)
 
-		// Create symlink in /etc/systemd/system/
-		if err := os.Symlink(servicePath, symlinkPath); err != nil {
+		// Create symlink in /etc/systemd/system/ pointing to current version
+		if err := os.Symlink(currentServicePath, symlinkPath); err != nil {
 			return fmt.Errorf("failed to create symlink for %s: %w", svc.Name, err)
 		}
 	}
@@ -272,3 +272,4 @@ type ServiceFile struct {
 	SourcePath string // Where to write the actual file
 	TargetPath string // Where to create the symlink
 }
+


### PR DESCRIPTION
A follow on to https://github.com/storacha/piri/pull/240/

This change does two things: 
It ensures when a rollback happens, we delete the binary causing the failure and re-install it.
Additionally, in #240 systemd weren't versioned, this will cause issues during updates when service requirements changed. i.e. Service files could get out of sync with binary versions. Maybe we want a longer shutdown timeout, etc.
So now we:
  - Versions systemd files in `/opt/piri/systemd/vX.Y.Z/` alongside binaries (same pattern)
  - Uses symlinks: `/opt/piri/systemd/current` -> `/opt/piri/systemd/vX.Y.Z`
  - Service files in `/etc/systemd/system/` symlink through current version
  - Updates both binary and systemd symlinks atomically during auto-update
