### PR TITLE
fix(aws): return store.ErrNotFound

### DIFF
--- a/pkg/aws/s3blobstore.go
+++ b/pkg/aws/s3blobstore.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,9 +15,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/multiformats/go-multicodec"
 	multihash "github.com/multiformats/go-multihash"
 	"github.com/storacha/go-libstoracha/digestutil"
+	"github.com/storacha/go-libstoracha/ipnipublisher/store"
 	"github.com/storacha/piri/pkg/presigner"
 	"github.com/storacha/piri/pkg/store/blobstore"
 )
@@ -154,6 +157,11 @@ func (s *S3BlobStore) Get(ctx context.Context, digest multihash.Multihash, opts 
 		Range:  rangeParam,
 	})
 	if err != nil {
+		var noSuchKeyError *types.NoSuchKey
+		// wrap in error recognizable as a not found error for Store interface consumers
+		if errors.As(err, &noSuchKeyError) {
+			return nil, store.NewErrNotFound(err)
+		}
 		return nil, err
 	}
 	return &s3BlobObject{outPut}, nil


### PR DESCRIPTION
# Goals

When a user performs an incomplete upload, where the blob is allocated but not received in full (i.e. http/put fails) -- they currently won't be able to upload again later, because we incorrectly see a blob store read error when the error is actually that the blob is not found when using the AWS blob store

# Implementation

- check for AWS no such key error and convert to ErrNotFound
