### PR TITLE
feat: implement provider registration

### DIFF
--- a/cmd/cli/client/pdp/provider/register.go
+++ b/cmd/cli/client/pdp/provider/register.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/storacha/piri/pkg/config"
+	"github.com/storacha/piri/pkg/pdp/httpapi/client"
+	"github.com/storacha/piri/pkg/pdp/types"
+)
+
+var (
+	RegisterCmd = &cobra.Command{
+		Use:   "register",
+		Short: "Register as a service provider",
+		Args:  cobra.NoArgs,
+		RunE:  doRegister,
+	}
+)
+
+func init() {
+	RegisterCmd.Flags().String(
+		"name",
+		"",
+		"Provider name (optional, max 128 chars)",
+	)
+
+	RegisterCmd.Flags().String(
+		"description",
+		"",
+		"Provider description (optional, max 256 chars)",
+	)
+	cobra.CheckErr(RegisterCmd.MarkFlagRequired("name"))
+	cobra.CheckErr(RegisterCmd.MarkFlagRequired("description"))
+}
+
+func doRegister(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	cfg, err := config.Load[config.Client]()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	pdpClient, err := client.NewFromConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("creating pdp client: %w", err)
+	}
+
+	name, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return fmt.Errorf("loading name flag: %w", err)
+	}
+
+	description, err := cmd.Flags().GetString("description")
+	if err != nil {
+		return fmt.Errorf("loading description flag: %w", err)
+	}
+
+	result, err := pdpClient.RegisterProvider(ctx, types.RegisterProviderParams{
+		Name:        name,
+		Description: description,
+	})
+	if err != nil {
+		return fmt.Errorf("registering provider: %w", err)
+	}
+
+	jsonResult, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("rendering json: %w", err)
+	}
+
+	cmd.Print(string(jsonResult))
+	return nil
+}

--- a/cmd/cli/client/pdp/provider/root.go
+++ b/cmd/cli/client/pdp/provider/root.go
@@ -1,0 +1,16 @@
+package provider
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	Cmd = &cobra.Command{
+		Use:   "provider",
+		Short: "Interact with PDP provider operations",
+	}
+)
+
+func init() {
+	Cmd.AddCommand(RegisterCmd)
+}

--- a/cmd/cli/client/pdp/root.go
+++ b/cmd/cli/client/pdp/root.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/storacha/piri/cmd/cli/client/pdp/proofset"
+	"github.com/storacha/piri/cmd/cli/client/pdp/provider"
 )
 
 var Cmd = &cobra.Command{
@@ -13,4 +14,5 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(proofset.Cmd)
+	Cmd.AddCommand(provider.Cmd)
 }

--- a/pkg/pdp/httpapi/server/register.go
+++ b/pkg/pdp/httpapi/server/register.go
@@ -52,4 +52,7 @@ func (p *PDPHandler) RegisterRoutes(e *echo.Echo) {
 	e.POST(path.Join(PDPRoutePath, PiecePrefix), p.handlePreparePiece)
 	e.PUT(path.Join(PDPRoutePath, PiecePrefix, "/upload/:uploadUUID"), p.handlePieceUpload)
 	e.GET(path.Join(PDPRoutePath, PiecePrefix), p.handleFindPiece)
+
+	// /pdp/provider
+	e.POST(path.Join(PDPRoutePath, "/provider/register"), p.handleRegisterProvider)
 }

--- a/pkg/pdp/httpapi/server/register_provider.go
+++ b/pkg/pdp/httpapi/server/register_provider.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/storacha/piri/pkg/pdp/httpapi"
+	"github.com/storacha/piri/pkg/pdp/httpapi/server/middleware"
+	"github.com/storacha/piri/pkg/pdp/types"
+)
+
+// handleRegisterProvider -> POST /pdp/provider
+func (p *PDPHandler) handleRegisterProvider(c echo.Context) error {
+	ctx := c.Request().Context()
+	operation := "RegisterProvider"
+
+	var req httpapi.RegisterProviderRequest
+	if err := c.Bind(&req); err != nil {
+		return middleware.NewError(operation, "Invalid request body", err, http.StatusBadRequest)
+	}
+
+	log.Debugw("Processing RegisterProvider request", "name", req.Name, "description", req.Description)
+
+	result, err := p.Service.RegisterProvider(ctx, types.RegisterProviderParams{
+		Name:        req.Name,
+		Description: req.Description,
+	})
+	if err != nil {
+		return middleware.NewError(operation, "Failed to register provider", err, http.StatusInternalServerError)
+	}
+
+	resp := httpapi.RegisterProviderResponse{
+		TxHash:      result.TransactionHash.Hex(),
+		Address:     result.Address.Hex(),
+		Payee:       result.Payee.Hex(),
+		ID:          result.ID,
+		IsActive:    result.IsActive,
+		Name:        result.Name,
+		Description: result.Description,
+	}
+
+	log.Infow("Successfully processed provider registration", "txHash", result.TransactionHash.Hex(), "providerId", result.ID)
+	return c.JSON(http.StatusCreated, resp)
+}

--- a/pkg/pdp/httpapi/types.go
+++ b/pkg/pdp/httpapi/types.go
@@ -171,3 +171,21 @@ type (
 		PieceCID string `json:"piece_cid"`
 	}
 )
+
+// RegisterProvider types
+type (
+	RegisterProviderRequest struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	RegisterProviderResponse struct {
+		TxHash      string `json:"txHash,omitempty"`
+		Address     string `json:"address,omitempty"`
+		Payee       string `json:"payee,omitempty"`
+		ID          uint64 `json:"id,omitempty"`
+		IsActive    bool   `json:"isActive,omitempty"`
+		Name        string `json:"name,omitempty"`
+		Description string `json:"description,omitempty"`
+	}
+)

--- a/pkg/pdp/service/provider_register.go
+++ b/pkg/pdp/service/provider_register.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/storacha/piri/pkg/pdp/types"
+	"gorm.io/gorm"
+
+	"github.com/storacha/piri/pkg/pdp/service/models"
+	"github.com/storacha/piri/pkg/pdp/smartcontracts"
+	"github.com/storacha/piri/pkg/pdp/smartcontracts/bindings"
+)
+
+func (p *PDPService) RegisterProvider(ctx context.Context, params types.RegisterProviderParams) (types.RegisterProviderResults, error) {
+	// TODO(forrest): remove this once confident in the code
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in RegisterProvider", r)
+		}
+	}()
+	bindCtx := &bind.CallOpts{Context: ctx}
+	registry, err := bindings.NewServiceProviderRegistry(smartcontracts.Addresses().ProviderRegistry, p.contractBackend)
+	if err != nil {
+		return types.RegisterProviderResults{}, fmt.Errorf("failed to create service registry binding: %w", err)
+	}
+
+	isRegistered, err := registry.IsRegisteredProvider(bindCtx, p.address)
+	if err != nil {
+		return types.RegisterProviderResults{}, fmt.Errorf("failed to check if service provider is registered: %w", err)
+	}
+
+	if isRegistered {
+		// TODO we can move this to a separate method for query provider, doing this here because its easy and I lazy.
+		providerInfoView, err := registry.GetProviderByAddress(bindCtx, p.address)
+		if err != nil {
+			return types.RegisterProviderResults{}, fmt.Errorf("failed to get provider by address for registered provider: %w", err)
+		}
+		log.Errorf("service provider %s is already registered with address %s", providerInfoView.ProviderId, p.address)
+		return types.RegisterProviderResults{
+			Address:     providerInfoView.Info.ServiceProvider,
+			Payee:       providerInfoView.Info.Payee,
+			ID:          providerInfoView.ProviderId.Uint64(),
+			IsActive:    providerInfoView.Info.IsActive,
+			Name:        providerInfoView.Info.Name,
+			Description: providerInfoView.Info.Description,
+		}, nil
+	}
+
+	// not registered, lets do this
+	abiData, err := bindings.ServiceProviderRegistryMetaData.GetAbi()
+	if err != nil {
+		return types.RegisterProviderResults{}, fmt.Errorf("failed to get ABI: %w", err)
+	}
+
+	/*
+	 /// @notice Register as a new service provider with a specific product type
+	    /// @param payee Address that will receive payments (cannot be changed after registration)
+	    /// @param name Provider name (optional, max 128 chars)
+	    /// @param description Provider description (max 256 chars)
+	    /// @param productType The type of product to register
+	    /// @param productData The encoded product configuration data
+	    /// @param capabilityKeys Array of capability keys
+	    /// @param capabilityValues Array of capability values
+	    /// @return providerId The unique ID assigned to the provider
+	    function registerProvider(
+	        address payee,
+	        string calldata name,
+	        string calldata description,
+	        ProductType productType,
+	        bytes calldata productData,
+	        string[] calldata capabilityKeys,
+	        string[] calldata capabilityValues
+	    ) external payable returns (uint256 providerId) {
+	*/
+
+	/*
+		The PDPOffering data (serviceURL, minPieceSizeInBytes,
+		  maxPieceSizeInBytes, storagePricePerTibPerMonth, etc.) is completely
+		  ignored.
+		  Instead, FilecoinWarmStorageService uses its own:
+		  - Fixed pricing: 5 USDFC per TiB/month (line 302)
+		  - Fixed proving periods: Set during initialization (lines 345-346)
+		  - No piece size restrictions from PDPOffering
+		  So, the PDPOffering is just stored in the
+		  registry for discovery/informational purposes. It's not used
+		  operationally by the FilecoinWarmStorageService contract.
+		  This makes sense architecturally because:
+		  1. The registry acts as a "yellow pages" where providers advertise their
+		  capabilities
+		  2. The actual service contract (FilecoinWarmStorageService) enforces its
+		  own standardized terms
+		  3. Clients might use PDPOffering data to discover providers, but the
+		  actual service operates on fixed terms
+	*/
+	productData, err := registry.EncodePDPOffering(bindCtx, bindings.ServiceProviderRegistryStoragePDPOffering{
+		// so I don't think any of these fields matter, see above comment
+		// TODO validate this assumption, I don't think it's used, but need to verify
+		ServiceURL:                 "http://example.com",
+		MinPieceSizeInBytes:        big.NewInt(1),
+		MaxPieceSizeInBytes:        big.NewInt(2),
+		IpniPiece:                  false,
+		IpniIpfs:                   false,
+		StoragePricePerTibPerMonth: big.NewInt(2),
+		MinProvingPeriodInEpochs:   big.NewInt(30),
+		Location:                   "earth",
+		PaymentTokenAddress:        p.address,
+	})
+	if err != nil {
+		return types.RegisterProviderResults{}, fmt.Errorf("failed to encode product data: %w", err)
+	}
+
+	data, err := abiData.Pack("registerProvider", p.address, params.Name, params.Description, types.ProductTypePDP,
+		productData, []string{}, []string{})
+	if err != nil {
+		return types.RegisterProviderResults{}, fmt.Errorf("failed to pack register message abi: %w", err)
+	}
+
+	tx := ethtypes.NewTransaction(
+		0,
+		smartcontracts.Addresses().ProviderRegistry,
+		smartcontracts.RegisterProviderFee(),
+		0,
+		nil,
+		data,
+	)
+
+	reason := "register_provider"
+	txHash, err := p.sender.Send(ctx, p.address, tx, reason)
+	if err != nil {
+		return types.RegisterProviderResults{}, fmt.Errorf("failed to send transaction: %w", err)
+	}
+
+	// NB(forrest): we could define a new database model and task, e.g. watch_providerregister.go that listens
+	// for successful messages, parses the receipts, and stores the provider ID in the database.
+	// But that's a lot of work for something that will really only happen once in a providers' lifetime.
+	// so instead, at the top of this function we just check if the provider is registered, and if they are return the
+	// providerID, allowing this method to be called repeatedly until an ID is returned, which is lazy...so
+	// TODO: evaluate this comment, and complete it or delete the comment and TODO
+	if err := p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		msgWait := models.MessageWaitsEth{
+			SignedTxHash: txHash.Hex(),
+			TxStatus:     "pending",
+		}
+		if err := tx.Create(&msgWait).Error; err != nil {
+			return fmt.Errorf("failed to insert into %s: %w", msgWait.TableName(), err)
+		}
+
+		// Return nil to commit the transaction.
+		return nil
+	}); err != nil {
+		return types.RegisterProviderResults{}, err
+	}
+
+	return types.RegisterProviderResults{
+		TransactionHash: txHash,
+	}, nil
+}

--- a/pkg/pdp/smartcontracts/abis/ServiceProviderRegistry.abi.json
+++ b/pkg/pdp/smartcontracts/abis/ServiceProviderRegistry.abi.json
@@ -1,0 +1,1774 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "BURN_ACTOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_CAPABILITIES",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_CAPABILITY_KEY_LENGTH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_CAPABILITY_VALUE_LENGTH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "REGISTRATION_FEE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "activeProductTypeProviderCount",
+    "inputs": [
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "activeProviderCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "addProduct",
+    "inputs": [
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "productData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "capabilityKeys",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "capabilityValues",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addressToProviderId",
+    "inputs": [
+      {
+        "name": "providerAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decodePDPOffering",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ServiceProviderRegistryStorage.PDPOffering",
+        "components": [
+          {
+            "name": "serviceURL",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "minPieceSizeInBytes",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxPieceSizeInBytes",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ipniPiece",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "ipniIpfs",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "storagePricePerTibPerMonth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "minProvingPeriodInEpochs",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "location",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "paymentTokenAddress",
+            "type": "address",
+            "internalType": "contract IERC20"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "encodePDPOffering",
+    "inputs": [
+      {
+        "name": "pdpOffering",
+        "type": "tuple",
+        "internalType": "struct ServiceProviderRegistryStorage.PDPOffering",
+        "components": [
+          {
+            "name": "serviceURL",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "minPieceSizeInBytes",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxPieceSizeInBytes",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ipniPiece",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "ipniIpfs",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "storagePricePerTibPerMonth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "minProvingPeriodInEpochs",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "location",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "paymentTokenAddress",
+            "type": "address",
+            "internalType": "contract IERC20"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getActiveProvidersByProductType",
+    "inputs": [
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result",
+        "type": "tuple",
+        "internalType": "struct ServiceProviderRegistryStorage.PaginatedProviders",
+        "components": [
+          {
+            "name": "providers",
+            "type": "tuple[]",
+            "internalType": "struct ServiceProviderRegistryStorage.ProviderWithProduct[]",
+            "components": [
+              {
+                "name": "providerId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "providerInfo",
+                "type": "tuple",
+                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+                "components": [
+                  {
+                    "name": "serviceProvider",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "payee",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "description",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "isActive",
+                    "type": "bool",
+                    "internalType": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "product",
+                "type": "tuple",
+                "internalType": "struct ServiceProviderRegistryStorage.ServiceProduct",
+                "components": [
+                  {
+                    "name": "productType",
+                    "type": "uint8",
+                    "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+                  },
+                  {
+                    "name": "productData",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  },
+                  {
+                    "name": "capabilityKeys",
+                    "type": "string[]",
+                    "internalType": "string[]"
+                  },
+                  {
+                    "name": "isActive",
+                    "type": "bool",
+                    "internalType": "bool"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "hasMore",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllActiveProviders",
+    "inputs": [
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "providerIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "hasMore",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextProviderId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPDPService",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "pdpOffering",
+        "type": "tuple",
+        "internalType": "struct ServiceProviderRegistryStorage.PDPOffering",
+        "components": [
+          {
+            "name": "serviceURL",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "minPieceSizeInBytes",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxPieceSizeInBytes",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ipniPiece",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "ipniIpfs",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "storagePricePerTibPerMonth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "minProvingPeriodInEpochs",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "location",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "paymentTokenAddress",
+            "type": "address",
+            "internalType": "contract IERC20"
+          }
+        ]
+      },
+      {
+        "name": "capabilityKeys",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "isActive",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProduct",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "productData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "capabilityKeys",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "isActive",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProductCapabilities",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "keys",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "exists",
+        "type": "bool[]",
+        "internalType": "bool[]"
+      },
+      {
+        "name": "values",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProductCapability",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "exists",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProvider",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "info",
+        "type": "tuple",
+        "internalType": "struct ServiceProviderRegistry.ServiceProviderInfoView",
+        "components": [
+          {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "info",
+            "type": "tuple",
+            "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+            "components": [
+              {
+                "name": "serviceProvider",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "payee",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "isActive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProviderByAddress",
+    "inputs": [
+      {
+        "name": "providerAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "info",
+        "type": "tuple",
+        "internalType": "struct ServiceProviderRegistry.ServiceProviderInfoView",
+        "components": [
+          {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "info",
+            "type": "tuple",
+            "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+            "components": [
+              {
+                "name": "serviceProvider",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "payee",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "isActive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProviderCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProviderIdByAddress",
+    "inputs": [
+      {
+        "name": "providerAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProviderPayee",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payee",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProvidersByIds",
+    "inputs": [
+      {
+        "name": "providerIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "providerInfos",
+        "type": "tuple[]",
+        "internalType": "struct ServiceProviderRegistry.ServiceProviderInfoView[]",
+        "components": [
+          {
+            "name": "providerId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "info",
+            "type": "tuple",
+            "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+            "components": [
+              {
+                "name": "serviceProvider",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "payee",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "description",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "isActive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "validIds",
+        "type": "bool[]",
+        "internalType": "bool[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProvidersByProductType",
+    "inputs": [
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result",
+        "type": "tuple",
+        "internalType": "struct ServiceProviderRegistryStorage.PaginatedProviders",
+        "components": [
+          {
+            "name": "providers",
+            "type": "tuple[]",
+            "internalType": "struct ServiceProviderRegistryStorage.ProviderWithProduct[]",
+            "components": [
+              {
+                "name": "providerId",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "providerInfo",
+                "type": "tuple",
+                "internalType": "struct ServiceProviderRegistryStorage.ServiceProviderInfo",
+                "components": [
+                  {
+                    "name": "serviceProvider",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "payee",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "description",
+                    "type": "string",
+                    "internalType": "string"
+                  },
+                  {
+                    "name": "isActive",
+                    "type": "bool",
+                    "internalType": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "product",
+                "type": "tuple",
+                "internalType": "struct ServiceProviderRegistryStorage.ServiceProduct",
+                "components": [
+                  {
+                    "name": "productType",
+                    "type": "uint8",
+                    "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+                  },
+                  {
+                    "name": "productData",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  },
+                  {
+                    "name": "capabilityKeys",
+                    "type": "string[]",
+                    "internalType": "string[]"
+                  },
+                  {
+                    "name": "isActive",
+                    "type": "bool",
+                    "internalType": "bool"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "hasMore",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isProviderActive",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isRegisteredProvider",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [
+      {
+        "name": "newVersion",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "productCapabilities",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "key",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "value",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "productTypeProviderCount",
+    "inputs": [
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "count",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "providerHasProduct",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "providerProducts",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "productData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "isActive",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "providers",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "serviceProvider",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "payee",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "isActive",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registerProvider",
+    "inputs": [
+      {
+        "name": "payee",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "productData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "capabilityKeys",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "capabilityValues",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "removeProduct",
+    "inputs": [
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removeProvider",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePDPServiceWithCapabilities",
+    "inputs": [
+      {
+        "name": "pdpOffering",
+        "type": "tuple",
+        "internalType": "struct ServiceProviderRegistryStorage.PDPOffering",
+        "components": [
+          {
+            "name": "serviceURL",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "minPieceSizeInBytes",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxPieceSizeInBytes",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ipniPiece",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "ipniIpfs",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "storagePricePerTibPerMonth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "minProvingPeriodInEpochs",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "location",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "paymentTokenAddress",
+            "type": "address",
+            "internalType": "contract IERC20"
+          }
+        ]
+      },
+      {
+        "name": "capabilityKeys",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "capabilityValues",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateProduct",
+    "inputs": [
+      {
+        "name": "productType",
+        "type": "uint8",
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "productData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "capabilityKeys",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "capabilityValues",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateProviderInfo",
+    "inputs": [
+      {
+        "name": "name",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "description",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "ContractUpgraded",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProductAdded",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "serviceUrl",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "serviceProvider",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "capabilityKeys",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
+      },
+      {
+        "name": "capabilityValues",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProductRemoved",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProductUpdated",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "productType",
+        "type": "uint8",
+        "indexed": true,
+        "internalType": "enum ServiceProviderRegistryStorage.ProductType"
+      },
+      {
+        "name": "serviceUrl",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "serviceProvider",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "capabilityKeys",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
+      },
+      {
+        "name": "capabilityValues",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProviderInfoUpdated",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProviderRegistered",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "serviceProvider",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "payee",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProviderRemoved",
+    "inputs": [
+      {
+        "name": "providerId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  }
+]

--- a/pkg/pdp/smartcontracts/addresses.go
+++ b/pkg/pdp/smartcontracts/addresses.go
@@ -9,7 +9,9 @@ import (
 )
 
 type PDPContracts struct {
-	PDPVerifier common.Address
+	PDPVerifier      common.Address
+	ProviderRegistry common.Address
+	PDPService       common.Address
 }
 
 func Addresses() PDPContracts {
@@ -19,11 +21,22 @@ func Addresses() PDPContracts {
 	return PDPContracts{
 		// PDPVerifier contract address
 		PDPVerifier: common.HexToAddress("0x445238Eca6c6aB8Dff1Aa6087d9c05734D22f137"),
+		// This contract and its address are owned by storacha
+		ProviderRegistry: common.HexToAddress("0x0aD6636eE10682232320356bc904ab07f8837bB1"),
+		// This contract and its address are owned by storacha, and uses ProviderRegistry for membership
+		PDPService: common.HexToAddress("0x8b7aa0a68f5717e400F1C4D37F7a28f84f76dF91"),
 	}
 }
 
+// NB: definion here: https://github.com/storacha/filecoin-services/blob/main/service_contracts/src/FilecoinWarmStorageService.sol#L23
 const NumChallenges = 5
 
+// NB: defintion here: https://github.com/FilOzone/pdp/blob/main/src/Fees.sol#L11
 func SybilFee() *big.Int {
 	return must.One(types.ParseFIL("0.1")).Int
+}
+
+// NB: definition here: https://github.com/storacha/filecoin-services/blob/main/service_contracts/src/ServiceProviderRegistry.sol#L54
+func RegisterProviderFee() *big.Int {
+	return must.One(types.ParseFIL("5")).Int
 }

--- a/pkg/pdp/smartcontracts/bindings/filecoin_warm_storage_service.go
+++ b/pkg/pdp/smartcontracts/bindings/filecoin_warm_storage_service.go
@@ -1,0 +1,4266 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// CidsCid is an auto generated low-level Go binding around an user-defined struct.
+
+// FilecoinWarmStorageServiceServicePricing is an auto generated low-level Go binding around an user-defined struct.
+type FilecoinWarmStorageServiceServicePricing struct {
+	PricePerTiBPerMonthNoCDN   *big.Int
+	PricePerTiBPerMonthWithCDN *big.Int
+	TokenAddress               common.Address
+	EpochsPerMonth             *big.Int
+}
+
+// IValidatorValidationResult is an auto generated low-level Go binding around an user-defined struct.
+type IValidatorValidationResult struct {
+	ModifiedAmount *big.Int
+	SettleUpto     *big.Int
+	Note           string
+}
+
+// FilecoinWarmStorageServiceMetaData contains all meta data concerning the FilecoinWarmStorageService contract.
+var FilecoinWarmStorageServiceMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"_pdpVerifierAddress\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_paymentsContractAddress\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_usdfc\",\"type\":\"address\",\"internalType\":\"contractIERC20Metadata\"},{\"name\":\"_filCDNBeneficiaryAddress\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_serviceProviderRegistry\",\"type\":\"address\",\"internalType\":\"contractServiceProviderRegistry\"},{\"name\":\"_sessionKeyRegistry\",\"type\":\"address\",\"internalType\":\"contractSessionKeyRegistry\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"addApprovedProvider\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"calculateRatesPerEpoch\",\"inputs\":[{\"name\":\"totalBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"storageRate\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"cacheMissRate\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"cdnRate\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"configureProvingPeriod\",\"inputs\":[{\"name\":\"_maxProvingPeriod\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"_challengeWindowSize\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"dataSetCreated\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"serviceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"extraData\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"dataSetDeleted\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"extraData\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"eip712Domain\",\"inputs\":[],\"outputs\":[{\"name\":\"fields\",\"type\":\"bytes1\",\"internalType\":\"bytes1\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"salt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"extensions\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"extsload\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"extsloadStruct\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"size\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32[]\",\"internalType\":\"bytes32[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"filCDNBeneficiaryAddress\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getEffectiveRates\",\"inputs\":[],\"outputs\":[{\"name\":\"serviceFee\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"spPayment\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProvingPeriodForEpoch\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"epoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getServicePrice\",\"inputs\":[],\"outputs\":[{\"name\":\"pricing\",\"type\":\"tuple\",\"internalType\":\"structFilecoinWarmStorageService.ServicePricing\",\"components\":[{\"name\":\"pricePerTiBPerMonthNoCDN\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pricePerTiBPerMonthWithCDN\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"tokenAddress\",\"type\":\"address\",\"internalType\":\"contractIERC20\"},{\"name\":\"epochsPerMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"_maxProvingPeriod\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"_challengeWindowSize\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_filCDNControllerAddress\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"_description\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isEpochProven\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"epoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"migrate\",\"inputs\":[{\"name\":\"_viewContract\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"nextProvingPeriod\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"challengeEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"leafCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"paymentsContractAddress\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pdpVerifierAddress\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"piecesAdded\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"firstAdded\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pieceData\",\"type\":\"tuple[]\",\"internalType\":\"structCids.Cid[]\",\"components\":[{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"extraData\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"piecesScheduledRemove\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pieceIds\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"},{\"name\":\"extraData\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"possessionProven\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"challengeCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"railTerminated\",\"inputs\":[{\"name\":\"railId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"terminator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"endEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"removeApprovedProvider\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"serviceCommissionBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"serviceProviderRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractServiceProviderRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"sessionKeyRegistry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractSessionKeyRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setViewContract\",\"inputs\":[{\"name\":\"_viewContract\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"storageProviderChanged\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"oldServiceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"newServiceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"terminateCDNService\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"terminateService\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFilCDNController\",\"inputs\":[{\"name\":\"newController\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateServiceCommission\",\"inputs\":[{\"name\":\"newCommissionBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"usdfcTokenAddress\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIERC20Metadata\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"validatePayment\",\"inputs\":[{\"name\":\"railId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"proposedAmount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"fromEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"toEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"result\",\"type\":\"tuple\",\"internalType\":\"structIValidator.ValidationResult\",\"components\":[{\"name\":\"modifiedAmount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"settleUpto\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"note\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"viewContractAddress\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"CDNPaymentTerminated\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"endEpoch\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"cacheMissRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"cdnRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"CDNServiceTerminated\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"cacheMissRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"cdnRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ContractUpgraded\",\"inputs\":[{\"name\":\"version\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DataSetCreated\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"pdpRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"cacheMissRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"cdnRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"payer\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"serviceProvider\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"metadataKeys\",\"type\":\"string[]\",\"indexed\":false,\"internalType\":\"string[]\"},{\"name\":\"metadataValues\",\"type\":\"string[]\",\"indexed\":false,\"internalType\":\"string[]\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DataSetServiceProviderChanged\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"oldServiceProvider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newServiceProvider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"EIP712DomainChanged\",\"inputs\":[],\"anonymous\":false},{\"type\":\"event\",\"name\":\"FaultRecord\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"periodsFaulted\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"deadline\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"FilCDNControllerChanged\",\"inputs\":[{\"name\":\"oldController\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newController\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"FilecoinServiceDeployed\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PDPPaymentTerminated\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"endEpoch\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"pdpRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PaymentArbitrated\",\"inputs\":[{\"name\":\"railId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"originalAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"modifiedAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"faultedEpochs\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"PieceAdded\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"pieceId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"pieceCid\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structCids.Cid\",\"components\":[{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"keys\",\"type\":\"string[]\",\"indexed\":false,\"internalType\":\"string[]\"},{\"name\":\"values\",\"type\":\"string[]\",\"indexed\":false,\"internalType\":\"string[]\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderApproved\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderUnapproved\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RailRateUpdated\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"railId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newRate\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ServiceTerminated\",\"inputs\":[{\"name\":\"caller\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"dataSetId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"pdpRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"cacheMissRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"cdnRailId\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ViewContractSet\",\"inputs\":[{\"name\":\"viewContract\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"CallerNotPayerOrPayee\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"expectedPayer\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"expectedPayee\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"CallerNotPayments\",\"inputs\":[{\"name\":\"expected\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"actual\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ChallengeWindowTooEarly\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"windowStart\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"nowBlock\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"CommissionExceedsMaximum\",\"inputs\":[{\"name\":\"commissionType\",\"type\":\"uint8\",\"internalType\":\"enumErrors.CommissionType\"},{\"name\":\"max\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actual\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"DataSetNotFoundForRail\",\"inputs\":[{\"name\":\"railId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"DataSetNotRegistered\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"DataSetPaymentAlreadyTerminated\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"DataSetPaymentBeyondEndEpoch\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pdpEndEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"currentBlock\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"DivisionByZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DuplicateMetadataKey\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"key\",\"type\":\"string\",\"internalType\":\"string\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExtraDataRequired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FilCDNPaymentAlreadyTerminated\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"FilCDNServiceNotConfigured\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidChallengeCount\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minExpected\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actual\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidChallengeEpoch\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actual\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidChallengeWindowSize\",\"inputs\":[{\"name\":\"maxProvingPeriod\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"challengeWindowSize\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidDataSetId\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidEpochRange\",\"inputs\":[{\"name\":\"fromEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"toEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidSignature\",\"inputs\":[{\"name\":\"expected\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"actual\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"InvalidSignatureLength\",\"inputs\":[{\"name\":\"expectedLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actualLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"MaxProvingPeriodZero\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"MetadataArrayCountMismatch\",\"inputs\":[{\"name\":\"metadataArrayCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pieceCount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"MetadataKeyAndValueLengthMismatch\",\"inputs\":[{\"name\":\"keysLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"valuesLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"MetadataKeyExceedsMaxLength\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"length\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"MetadataValueExceedsMaxLength\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"length\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NextProvingPeriodAlreadyCalled\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"periodDeadline\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"nowBlock\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NoPDPPaymentRail\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OldServiceProviderMismatch\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"expected\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"actual\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OnlyFilCDNControllerAllowed\",\"inputs\":[{\"name\":\"expected\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"actual\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OnlyPDPVerifierAllowed\",\"inputs\":[{\"name\":\"expected\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"actual\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OnlySelf\",\"inputs\":[{\"name\":\"expected\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"actual\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"PaymentRailsNotFinalized\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"pdpEndEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"cdnEndEpoch\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProofAlreadySubmitted\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProviderAlreadyApproved\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProviderNotApproved\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProviderNotInApprovedList\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProviderNotRegistered\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ProvingNotStarted\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ProvingPeriodPassed\",\"inputs\":[{\"name\":\"dataSetId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deadline\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"nowBlock\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"RailNotAssociated\",\"inputs\":[{\"name\":\"railId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ServiceContractMustTerminateRail\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"TooManyMetadataKeys\",\"inputs\":[{\"name\":\"maxAllowed\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"keysLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"UnsupportedSignatureV\",\"inputs\":[{\"name\":\"v\",\"type\":\"uint8\",\"internalType\":\"uint8\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[{\"name\":\"field\",\"type\":\"uint8\",\"internalType\":\"enumErrors.AddressField\"}]}]",
+}
+
+// FilecoinWarmStorageServiceABI is the input ABI used to generate the binding from.
+// Deprecated: Use FilecoinWarmStorageServiceMetaData.ABI instead.
+var FilecoinWarmStorageServiceABI = FilecoinWarmStorageServiceMetaData.ABI
+
+// FilecoinWarmStorageService is an auto generated Go binding around an Ethereum contract.
+type FilecoinWarmStorageService struct {
+	FilecoinWarmStorageServiceCaller     // Read-only binding to the contract
+	FilecoinWarmStorageServiceTransactor // Write-only binding to the contract
+	FilecoinWarmStorageServiceFilterer   // Log filterer for contract events
+}
+
+// FilecoinWarmStorageServiceCaller is an auto generated read-only Go binding around an Ethereum contract.
+type FilecoinWarmStorageServiceCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FilecoinWarmStorageServiceTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type FilecoinWarmStorageServiceTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FilecoinWarmStorageServiceFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type FilecoinWarmStorageServiceFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FilecoinWarmStorageServiceSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type FilecoinWarmStorageServiceSession struct {
+	Contract     *FilecoinWarmStorageService // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts               // Call options to use throughout this session
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// FilecoinWarmStorageServiceCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type FilecoinWarmStorageServiceCallerSession struct {
+	Contract *FilecoinWarmStorageServiceCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                     // Call options to use throughout this session
+}
+
+// FilecoinWarmStorageServiceTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type FilecoinWarmStorageServiceTransactorSession struct {
+	Contract     *FilecoinWarmStorageServiceTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                     // Transaction auth options to use throughout this session
+}
+
+// FilecoinWarmStorageServiceRaw is an auto generated low-level Go binding around an Ethereum contract.
+type FilecoinWarmStorageServiceRaw struct {
+	Contract *FilecoinWarmStorageService // Generic contract binding to access the raw methods on
+}
+
+// FilecoinWarmStorageServiceCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type FilecoinWarmStorageServiceCallerRaw struct {
+	Contract *FilecoinWarmStorageServiceCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// FilecoinWarmStorageServiceTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type FilecoinWarmStorageServiceTransactorRaw struct {
+	Contract *FilecoinWarmStorageServiceTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewFilecoinWarmStorageService creates a new instance of FilecoinWarmStorageService, bound to a specific deployed contract.
+func NewFilecoinWarmStorageService(address common.Address, backend bind.ContractBackend) (*FilecoinWarmStorageService, error) {
+	contract, err := bindFilecoinWarmStorageService(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageService{FilecoinWarmStorageServiceCaller: FilecoinWarmStorageServiceCaller{contract: contract}, FilecoinWarmStorageServiceTransactor: FilecoinWarmStorageServiceTransactor{contract: contract}, FilecoinWarmStorageServiceFilterer: FilecoinWarmStorageServiceFilterer{contract: contract}}, nil
+}
+
+// NewFilecoinWarmStorageServiceCaller creates a new read-only instance of FilecoinWarmStorageService, bound to a specific deployed contract.
+func NewFilecoinWarmStorageServiceCaller(address common.Address, caller bind.ContractCaller) (*FilecoinWarmStorageServiceCaller, error) {
+	contract, err := bindFilecoinWarmStorageService(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceCaller{contract: contract}, nil
+}
+
+// NewFilecoinWarmStorageServiceTransactor creates a new write-only instance of FilecoinWarmStorageService, bound to a specific deployed contract.
+func NewFilecoinWarmStorageServiceTransactor(address common.Address, transactor bind.ContractTransactor) (*FilecoinWarmStorageServiceTransactor, error) {
+	contract, err := bindFilecoinWarmStorageService(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceTransactor{contract: contract}, nil
+}
+
+// NewFilecoinWarmStorageServiceFilterer creates a new log filterer instance of FilecoinWarmStorageService, bound to a specific deployed contract.
+func NewFilecoinWarmStorageServiceFilterer(address common.Address, filterer bind.ContractFilterer) (*FilecoinWarmStorageServiceFilterer, error) {
+	contract, err := bindFilecoinWarmStorageService(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceFilterer{contract: contract}, nil
+}
+
+// bindFilecoinWarmStorageService binds a generic wrapper to an already deployed contract.
+func bindFilecoinWarmStorageService(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := FilecoinWarmStorageServiceMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FilecoinWarmStorageService.Contract.FilecoinWarmStorageServiceCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.FilecoinWarmStorageServiceTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.FilecoinWarmStorageServiceTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FilecoinWarmStorageService.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.contract.Transact(opts, method, params...)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) UPGRADEINTERFACEVERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "UPGRADE_INTERFACE_VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _FilecoinWarmStorageService.Contract.UPGRADEINTERFACEVERSION(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _FilecoinWarmStorageService.Contract.UPGRADEINTERFACEVERSION(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) VERSION() (string, error) {
+	return _FilecoinWarmStorageService.Contract.VERSION(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) VERSION() (string, error) {
+	return _FilecoinWarmStorageService.Contract.VERSION(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// CalculateRatesPerEpoch is a free data retrieval call binding the contract method 0x4425b3a2.
+//
+// Solidity: function calculateRatesPerEpoch(uint256 totalBytes) view returns(uint256 storageRate, uint256 cacheMissRate, uint256 cdnRate)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) CalculateRatesPerEpoch(opts *bind.CallOpts, totalBytes *big.Int) (struct {
+	StorageRate   *big.Int
+	CacheMissRate *big.Int
+	CdnRate       *big.Int
+}, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "calculateRatesPerEpoch", totalBytes)
+
+	outstruct := new(struct {
+		StorageRate   *big.Int
+		CacheMissRate *big.Int
+		CdnRate       *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.StorageRate = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.CacheMissRate = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.CdnRate = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// CalculateRatesPerEpoch is a free data retrieval call binding the contract method 0x4425b3a2.
+//
+// Solidity: function calculateRatesPerEpoch(uint256 totalBytes) view returns(uint256 storageRate, uint256 cacheMissRate, uint256 cdnRate)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) CalculateRatesPerEpoch(totalBytes *big.Int) (struct {
+	StorageRate   *big.Int
+	CacheMissRate *big.Int
+	CdnRate       *big.Int
+}, error) {
+	return _FilecoinWarmStorageService.Contract.CalculateRatesPerEpoch(&_FilecoinWarmStorageService.CallOpts, totalBytes)
+}
+
+// CalculateRatesPerEpoch is a free data retrieval call binding the contract method 0x4425b3a2.
+//
+// Solidity: function calculateRatesPerEpoch(uint256 totalBytes) view returns(uint256 storageRate, uint256 cacheMissRate, uint256 cdnRate)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) CalculateRatesPerEpoch(totalBytes *big.Int) (struct {
+	StorageRate   *big.Int
+	CacheMissRate *big.Int
+	CdnRate       *big.Int
+}, error) {
+	return _FilecoinWarmStorageService.Contract.CalculateRatesPerEpoch(&_FilecoinWarmStorageService.CallOpts, totalBytes)
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) Eip712Domain(opts *bind.CallOpts) (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "eip712Domain")
+
+	outstruct := new(struct {
+		Fields            [1]byte
+		Name              string
+		Version           string
+		ChainId           *big.Int
+		VerifyingContract common.Address
+		Salt              [32]byte
+		Extensions        []*big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Fields = *abi.ConvertType(out[0], new([1]byte)).(*[1]byte)
+	outstruct.Name = *abi.ConvertType(out[1], new(string)).(*string)
+	outstruct.Version = *abi.ConvertType(out[2], new(string)).(*string)
+	outstruct.ChainId = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.VerifyingContract = *abi.ConvertType(out[4], new(common.Address)).(*common.Address)
+	outstruct.Salt = *abi.ConvertType(out[5], new([32]byte)).(*[32]byte)
+	outstruct.Extensions = *abi.ConvertType(out[6], new([]*big.Int)).(*[]*big.Int)
+
+	return *outstruct, err
+
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) Eip712Domain() (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	return _FilecoinWarmStorageService.Contract.Eip712Domain(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) Eip712Domain() (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	return _FilecoinWarmStorageService.Contract.Eip712Domain(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// Extsload is a free data retrieval call binding the contract method 0x1e2eaeaf.
+//
+// Solidity: function extsload(bytes32 slot) view returns(bytes32)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) Extsload(opts *bind.CallOpts, slot [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "extsload", slot)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// Extsload is a free data retrieval call binding the contract method 0x1e2eaeaf.
+//
+// Solidity: function extsload(bytes32 slot) view returns(bytes32)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) Extsload(slot [32]byte) ([32]byte, error) {
+	return _FilecoinWarmStorageService.Contract.Extsload(&_FilecoinWarmStorageService.CallOpts, slot)
+}
+
+// Extsload is a free data retrieval call binding the contract method 0x1e2eaeaf.
+//
+// Solidity: function extsload(bytes32 slot) view returns(bytes32)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) Extsload(slot [32]byte) ([32]byte, error) {
+	return _FilecoinWarmStorageService.Contract.Extsload(&_FilecoinWarmStorageService.CallOpts, slot)
+}
+
+// ExtsloadStruct is a free data retrieval call binding the contract method 0x5379a435.
+//
+// Solidity: function extsloadStruct(bytes32 slot, uint256 size) view returns(bytes32[])
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) ExtsloadStruct(opts *bind.CallOpts, slot [32]byte, size *big.Int) ([][32]byte, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "extsloadStruct", slot, size)
+
+	if err != nil {
+		return *new([][32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([][32]byte)).(*[][32]byte)
+
+	return out0, err
+
+}
+
+// ExtsloadStruct is a free data retrieval call binding the contract method 0x5379a435.
+//
+// Solidity: function extsloadStruct(bytes32 slot, uint256 size) view returns(bytes32[])
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) ExtsloadStruct(slot [32]byte, size *big.Int) ([][32]byte, error) {
+	return _FilecoinWarmStorageService.Contract.ExtsloadStruct(&_FilecoinWarmStorageService.CallOpts, slot, size)
+}
+
+// ExtsloadStruct is a free data retrieval call binding the contract method 0x5379a435.
+//
+// Solidity: function extsloadStruct(bytes32 slot, uint256 size) view returns(bytes32[])
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) ExtsloadStruct(slot [32]byte, size *big.Int) ([][32]byte, error) {
+	return _FilecoinWarmStorageService.Contract.ExtsloadStruct(&_FilecoinWarmStorageService.CallOpts, slot, size)
+}
+
+// FilCDNBeneficiaryAddress is a free data retrieval call binding the contract method 0xce4f8d8b.
+//
+// Solidity: function filCDNBeneficiaryAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) FilCDNBeneficiaryAddress(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "filCDNBeneficiaryAddress")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// FilCDNBeneficiaryAddress is a free data retrieval call binding the contract method 0xce4f8d8b.
+//
+// Solidity: function filCDNBeneficiaryAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) FilCDNBeneficiaryAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.FilCDNBeneficiaryAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// FilCDNBeneficiaryAddress is a free data retrieval call binding the contract method 0xce4f8d8b.
+//
+// Solidity: function filCDNBeneficiaryAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) FilCDNBeneficiaryAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.FilCDNBeneficiaryAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// GetEffectiveRates is a free data retrieval call binding the contract method 0x93124a79.
+//
+// Solidity: function getEffectiveRates() view returns(uint256 serviceFee, uint256 spPayment)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) GetEffectiveRates(opts *bind.CallOpts) (struct {
+	ServiceFee *big.Int
+	SpPayment  *big.Int
+}, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "getEffectiveRates")
+
+	outstruct := new(struct {
+		ServiceFee *big.Int
+		SpPayment  *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ServiceFee = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.SpPayment = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetEffectiveRates is a free data retrieval call binding the contract method 0x93124a79.
+//
+// Solidity: function getEffectiveRates() view returns(uint256 serviceFee, uint256 spPayment)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) GetEffectiveRates() (struct {
+	ServiceFee *big.Int
+	SpPayment  *big.Int
+}, error) {
+	return _FilecoinWarmStorageService.Contract.GetEffectiveRates(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// GetEffectiveRates is a free data retrieval call binding the contract method 0x93124a79.
+//
+// Solidity: function getEffectiveRates() view returns(uint256 serviceFee, uint256 spPayment)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) GetEffectiveRates() (struct {
+	ServiceFee *big.Int
+	SpPayment  *big.Int
+}, error) {
+	return _FilecoinWarmStorageService.Contract.GetEffectiveRates(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// GetProvingPeriodForEpoch is a free data retrieval call binding the contract method 0x4a1fd7a3.
+//
+// Solidity: function getProvingPeriodForEpoch(uint256 dataSetId, uint256 epoch) view returns(uint256)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) GetProvingPeriodForEpoch(opts *bind.CallOpts, dataSetId *big.Int, epoch *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "getProvingPeriodForEpoch", dataSetId, epoch)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetProvingPeriodForEpoch is a free data retrieval call binding the contract method 0x4a1fd7a3.
+//
+// Solidity: function getProvingPeriodForEpoch(uint256 dataSetId, uint256 epoch) view returns(uint256)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) GetProvingPeriodForEpoch(dataSetId *big.Int, epoch *big.Int) (*big.Int, error) {
+	return _FilecoinWarmStorageService.Contract.GetProvingPeriodForEpoch(&_FilecoinWarmStorageService.CallOpts, dataSetId, epoch)
+}
+
+// GetProvingPeriodForEpoch is a free data retrieval call binding the contract method 0x4a1fd7a3.
+//
+// Solidity: function getProvingPeriodForEpoch(uint256 dataSetId, uint256 epoch) view returns(uint256)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) GetProvingPeriodForEpoch(dataSetId *big.Int, epoch *big.Int) (*big.Int, error) {
+	return _FilecoinWarmStorageService.Contract.GetProvingPeriodForEpoch(&_FilecoinWarmStorageService.CallOpts, dataSetId, epoch)
+}
+
+// GetServicePrice is a free data retrieval call binding the contract method 0x5482bdf9.
+//
+// Solidity: function getServicePrice() view returns((uint256,uint256,address,uint256) pricing)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) GetServicePrice(opts *bind.CallOpts) (FilecoinWarmStorageServiceServicePricing, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "getServicePrice")
+
+	if err != nil {
+		return *new(FilecoinWarmStorageServiceServicePricing), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(FilecoinWarmStorageServiceServicePricing)).(*FilecoinWarmStorageServiceServicePricing)
+
+	return out0, err
+
+}
+
+// GetServicePrice is a free data retrieval call binding the contract method 0x5482bdf9.
+//
+// Solidity: function getServicePrice() view returns((uint256,uint256,address,uint256) pricing)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) GetServicePrice() (FilecoinWarmStorageServiceServicePricing, error) {
+	return _FilecoinWarmStorageService.Contract.GetServicePrice(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// GetServicePrice is a free data retrieval call binding the contract method 0x5482bdf9.
+//
+// Solidity: function getServicePrice() view returns((uint256,uint256,address,uint256) pricing)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) GetServicePrice() (FilecoinWarmStorageServiceServicePricing, error) {
+	return _FilecoinWarmStorageService.Contract.GetServicePrice(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// IsEpochProven is a free data retrieval call binding the contract method 0xdc960e2c.
+//
+// Solidity: function isEpochProven(uint256 dataSetId, uint256 epoch) view returns(bool)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) IsEpochProven(opts *bind.CallOpts, dataSetId *big.Int, epoch *big.Int) (bool, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "isEpochProven", dataSetId, epoch)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsEpochProven is a free data retrieval call binding the contract method 0xdc960e2c.
+//
+// Solidity: function isEpochProven(uint256 dataSetId, uint256 epoch) view returns(bool)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) IsEpochProven(dataSetId *big.Int, epoch *big.Int) (bool, error) {
+	return _FilecoinWarmStorageService.Contract.IsEpochProven(&_FilecoinWarmStorageService.CallOpts, dataSetId, epoch)
+}
+
+// IsEpochProven is a free data retrieval call binding the contract method 0xdc960e2c.
+//
+// Solidity: function isEpochProven(uint256 dataSetId, uint256 epoch) view returns(bool)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) IsEpochProven(dataSetId *big.Int, epoch *big.Int) (bool, error) {
+	return _FilecoinWarmStorageService.Contract.IsEpochProven(&_FilecoinWarmStorageService.CallOpts, dataSetId, epoch)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) Owner() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.Owner(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) Owner() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.Owner(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// PaymentsContractAddress is a free data retrieval call binding the contract method 0xbc471469.
+//
+// Solidity: function paymentsContractAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) PaymentsContractAddress(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "paymentsContractAddress")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PaymentsContractAddress is a free data retrieval call binding the contract method 0xbc471469.
+//
+// Solidity: function paymentsContractAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) PaymentsContractAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.PaymentsContractAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// PaymentsContractAddress is a free data retrieval call binding the contract method 0xbc471469.
+//
+// Solidity: function paymentsContractAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) PaymentsContractAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.PaymentsContractAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// PdpVerifierAddress is a free data retrieval call binding the contract method 0xde4b6b71.
+//
+// Solidity: function pdpVerifierAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) PdpVerifierAddress(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "pdpVerifierAddress")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PdpVerifierAddress is a free data retrieval call binding the contract method 0xde4b6b71.
+//
+// Solidity: function pdpVerifierAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) PdpVerifierAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.PdpVerifierAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// PdpVerifierAddress is a free data retrieval call binding the contract method 0xde4b6b71.
+//
+// Solidity: function pdpVerifierAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) PdpVerifierAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.PdpVerifierAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "proxiableUUID")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) ProxiableUUID() ([32]byte, error) {
+	return _FilecoinWarmStorageService.Contract.ProxiableUUID(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _FilecoinWarmStorageService.Contract.ProxiableUUID(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// ServiceCommissionBps is a free data retrieval call binding the contract method 0x2afcc1a4.
+//
+// Solidity: function serviceCommissionBps() view returns(uint256)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) ServiceCommissionBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "serviceCommissionBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ServiceCommissionBps is a free data retrieval call binding the contract method 0x2afcc1a4.
+//
+// Solidity: function serviceCommissionBps() view returns(uint256)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) ServiceCommissionBps() (*big.Int, error) {
+	return _FilecoinWarmStorageService.Contract.ServiceCommissionBps(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// ServiceCommissionBps is a free data retrieval call binding the contract method 0x2afcc1a4.
+//
+// Solidity: function serviceCommissionBps() view returns(uint256)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) ServiceCommissionBps() (*big.Int, error) {
+	return _FilecoinWarmStorageService.Contract.ServiceCommissionBps(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// ServiceProviderRegistry is a free data retrieval call binding the contract method 0x05f892ec.
+//
+// Solidity: function serviceProviderRegistry() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) ServiceProviderRegistry(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "serviceProviderRegistry")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ServiceProviderRegistry is a free data retrieval call binding the contract method 0x05f892ec.
+//
+// Solidity: function serviceProviderRegistry() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) ServiceProviderRegistry() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.ServiceProviderRegistry(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// ServiceProviderRegistry is a free data retrieval call binding the contract method 0x05f892ec.
+//
+// Solidity: function serviceProviderRegistry() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) ServiceProviderRegistry() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.ServiceProviderRegistry(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// SessionKeyRegistry is a free data retrieval call binding the contract method 0x9f6aa572.
+//
+// Solidity: function sessionKeyRegistry() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) SessionKeyRegistry(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "sessionKeyRegistry")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// SessionKeyRegistry is a free data retrieval call binding the contract method 0x9f6aa572.
+//
+// Solidity: function sessionKeyRegistry() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) SessionKeyRegistry() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.SessionKeyRegistry(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// SessionKeyRegistry is a free data retrieval call binding the contract method 0x9f6aa572.
+//
+// Solidity: function sessionKeyRegistry() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) SessionKeyRegistry() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.SessionKeyRegistry(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// UsdfcTokenAddress is a free data retrieval call binding the contract method 0xd39b33ab.
+//
+// Solidity: function usdfcTokenAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) UsdfcTokenAddress(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "usdfcTokenAddress")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// UsdfcTokenAddress is a free data retrieval call binding the contract method 0xd39b33ab.
+//
+// Solidity: function usdfcTokenAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) UsdfcTokenAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.UsdfcTokenAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// UsdfcTokenAddress is a free data retrieval call binding the contract method 0xd39b33ab.
+//
+// Solidity: function usdfcTokenAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) UsdfcTokenAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.UsdfcTokenAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// ViewContractAddress is a free data retrieval call binding the contract method 0x7a9ebc15.
+//
+// Solidity: function viewContractAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCaller) ViewContractAddress(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FilecoinWarmStorageService.contract.Call(opts, &out, "viewContractAddress")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ViewContractAddress is a free data retrieval call binding the contract method 0x7a9ebc15.
+//
+// Solidity: function viewContractAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) ViewContractAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.ViewContractAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// ViewContractAddress is a free data retrieval call binding the contract method 0x7a9ebc15.
+//
+// Solidity: function viewContractAddress() view returns(address)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceCallerSession) ViewContractAddress() (common.Address, error) {
+	return _FilecoinWarmStorageService.Contract.ViewContractAddress(&_FilecoinWarmStorageService.CallOpts)
+}
+
+// AddApprovedProvider is a paid mutator transaction binding the contract method 0xa71f9fec.
+//
+// Solidity: function addApprovedProvider(uint256 providerId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) AddApprovedProvider(opts *bind.TransactOpts, providerId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "addApprovedProvider", providerId)
+}
+
+// AddApprovedProvider is a paid mutator transaction binding the contract method 0xa71f9fec.
+//
+// Solidity: function addApprovedProvider(uint256 providerId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) AddApprovedProvider(providerId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.AddApprovedProvider(&_FilecoinWarmStorageService.TransactOpts, providerId)
+}
+
+// AddApprovedProvider is a paid mutator transaction binding the contract method 0xa71f9fec.
+//
+// Solidity: function addApprovedProvider(uint256 providerId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) AddApprovedProvider(providerId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.AddApprovedProvider(&_FilecoinWarmStorageService.TransactOpts, providerId)
+}
+
+// ConfigureProvingPeriod is a paid mutator transaction binding the contract method 0xcee4f4c7.
+//
+// Solidity: function configureProvingPeriod(uint64 _maxProvingPeriod, uint256 _challengeWindowSize) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) ConfigureProvingPeriod(opts *bind.TransactOpts, _maxProvingPeriod uint64, _challengeWindowSize *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "configureProvingPeriod", _maxProvingPeriod, _challengeWindowSize)
+}
+
+// ConfigureProvingPeriod is a paid mutator transaction binding the contract method 0xcee4f4c7.
+//
+// Solidity: function configureProvingPeriod(uint64 _maxProvingPeriod, uint256 _challengeWindowSize) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) ConfigureProvingPeriod(_maxProvingPeriod uint64, _challengeWindowSize *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.ConfigureProvingPeriod(&_FilecoinWarmStorageService.TransactOpts, _maxProvingPeriod, _challengeWindowSize)
+}
+
+// ConfigureProvingPeriod is a paid mutator transaction binding the contract method 0xcee4f4c7.
+//
+// Solidity: function configureProvingPeriod(uint64 _maxProvingPeriod, uint256 _challengeWindowSize) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) ConfigureProvingPeriod(_maxProvingPeriod uint64, _challengeWindowSize *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.ConfigureProvingPeriod(&_FilecoinWarmStorageService.TransactOpts, _maxProvingPeriod, _challengeWindowSize)
+}
+
+// DataSetCreated is a paid mutator transaction binding the contract method 0x101c1eab.
+//
+// Solidity: function dataSetCreated(uint256 dataSetId, address serviceProvider, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) DataSetCreated(opts *bind.TransactOpts, dataSetId *big.Int, serviceProvider common.Address, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "dataSetCreated", dataSetId, serviceProvider, extraData)
+}
+
+// DataSetCreated is a paid mutator transaction binding the contract method 0x101c1eab.
+//
+// Solidity: function dataSetCreated(uint256 dataSetId, address serviceProvider, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) DataSetCreated(dataSetId *big.Int, serviceProvider common.Address, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.DataSetCreated(&_FilecoinWarmStorageService.TransactOpts, dataSetId, serviceProvider, extraData)
+}
+
+// DataSetCreated is a paid mutator transaction binding the contract method 0x101c1eab.
+//
+// Solidity: function dataSetCreated(uint256 dataSetId, address serviceProvider, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) DataSetCreated(dataSetId *big.Int, serviceProvider common.Address, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.DataSetCreated(&_FilecoinWarmStorageService.TransactOpts, dataSetId, serviceProvider, extraData)
+}
+
+// DataSetDeleted is a paid mutator transaction binding the contract method 0x2abd465c.
+//
+// Solidity: function dataSetDeleted(uint256 dataSetId, uint256 , bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) DataSetDeleted(opts *bind.TransactOpts, dataSetId *big.Int, arg1 *big.Int, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "dataSetDeleted", dataSetId, arg1, extraData)
+}
+
+// DataSetDeleted is a paid mutator transaction binding the contract method 0x2abd465c.
+//
+// Solidity: function dataSetDeleted(uint256 dataSetId, uint256 , bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) DataSetDeleted(dataSetId *big.Int, arg1 *big.Int, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.DataSetDeleted(&_FilecoinWarmStorageService.TransactOpts, dataSetId, arg1, extraData)
+}
+
+// DataSetDeleted is a paid mutator transaction binding the contract method 0x2abd465c.
+//
+// Solidity: function dataSetDeleted(uint256 dataSetId, uint256 , bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) DataSetDeleted(dataSetId *big.Int, arg1 *big.Int, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.DataSetDeleted(&_FilecoinWarmStorageService.TransactOpts, dataSetId, arg1, extraData)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x46614302.
+//
+// Solidity: function initialize(uint64 _maxProvingPeriod, uint256 _challengeWindowSize, address _filCDNControllerAddress, string _name, string _description) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) Initialize(opts *bind.TransactOpts, _maxProvingPeriod uint64, _challengeWindowSize *big.Int, _filCDNControllerAddress common.Address, _name string, _description string) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "initialize", _maxProvingPeriod, _challengeWindowSize, _filCDNControllerAddress, _name, _description)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x46614302.
+//
+// Solidity: function initialize(uint64 _maxProvingPeriod, uint256 _challengeWindowSize, address _filCDNControllerAddress, string _name, string _description) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) Initialize(_maxProvingPeriod uint64, _challengeWindowSize *big.Int, _filCDNControllerAddress common.Address, _name string, _description string) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.Initialize(&_FilecoinWarmStorageService.TransactOpts, _maxProvingPeriod, _challengeWindowSize, _filCDNControllerAddress, _name, _description)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x46614302.
+//
+// Solidity: function initialize(uint64 _maxProvingPeriod, uint256 _challengeWindowSize, address _filCDNControllerAddress, string _name, string _description) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) Initialize(_maxProvingPeriod uint64, _challengeWindowSize *big.Int, _filCDNControllerAddress common.Address, _name string, _description string) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.Initialize(&_FilecoinWarmStorageService.TransactOpts, _maxProvingPeriod, _challengeWindowSize, _filCDNControllerAddress, _name, _description)
+}
+
+// Migrate is a paid mutator transaction binding the contract method 0xce5494bb.
+//
+// Solidity: function migrate(address _viewContract) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) Migrate(opts *bind.TransactOpts, _viewContract common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "migrate", _viewContract)
+}
+
+// Migrate is a paid mutator transaction binding the contract method 0xce5494bb.
+//
+// Solidity: function migrate(address _viewContract) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) Migrate(_viewContract common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.Migrate(&_FilecoinWarmStorageService.TransactOpts, _viewContract)
+}
+
+// Migrate is a paid mutator transaction binding the contract method 0xce5494bb.
+//
+// Solidity: function migrate(address _viewContract) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) Migrate(_viewContract common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.Migrate(&_FilecoinWarmStorageService.TransactOpts, _viewContract)
+}
+
+// NextProvingPeriod is a paid mutator transaction binding the contract method 0xaa27ebcc.
+//
+// Solidity: function nextProvingPeriod(uint256 dataSetId, uint256 challengeEpoch, uint256 leafCount, bytes ) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) NextProvingPeriod(opts *bind.TransactOpts, dataSetId *big.Int, challengeEpoch *big.Int, leafCount *big.Int, arg3 []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "nextProvingPeriod", dataSetId, challengeEpoch, leafCount, arg3)
+}
+
+// NextProvingPeriod is a paid mutator transaction binding the contract method 0xaa27ebcc.
+//
+// Solidity: function nextProvingPeriod(uint256 dataSetId, uint256 challengeEpoch, uint256 leafCount, bytes ) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) NextProvingPeriod(dataSetId *big.Int, challengeEpoch *big.Int, leafCount *big.Int, arg3 []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.NextProvingPeriod(&_FilecoinWarmStorageService.TransactOpts, dataSetId, challengeEpoch, leafCount, arg3)
+}
+
+// NextProvingPeriod is a paid mutator transaction binding the contract method 0xaa27ebcc.
+//
+// Solidity: function nextProvingPeriod(uint256 dataSetId, uint256 challengeEpoch, uint256 leafCount, bytes ) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) NextProvingPeriod(dataSetId *big.Int, challengeEpoch *big.Int, leafCount *big.Int, arg3 []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.NextProvingPeriod(&_FilecoinWarmStorageService.TransactOpts, dataSetId, challengeEpoch, leafCount, arg3)
+}
+
+// PiecesAdded is a paid mutator transaction binding the contract method 0xf6814d79.
+//
+// Solidity: function piecesAdded(uint256 dataSetId, uint256 firstAdded, (bytes)[] pieceData, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) PiecesAdded(opts *bind.TransactOpts, dataSetId *big.Int, firstAdded *big.Int, pieceData []CidsCid, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "piecesAdded", dataSetId, firstAdded, pieceData, extraData)
+}
+
+// PiecesAdded is a paid mutator transaction binding the contract method 0xf6814d79.
+//
+// Solidity: function piecesAdded(uint256 dataSetId, uint256 firstAdded, (bytes)[] pieceData, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) PiecesAdded(dataSetId *big.Int, firstAdded *big.Int, pieceData []CidsCid, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.PiecesAdded(&_FilecoinWarmStorageService.TransactOpts, dataSetId, firstAdded, pieceData, extraData)
+}
+
+// PiecesAdded is a paid mutator transaction binding the contract method 0xf6814d79.
+//
+// Solidity: function piecesAdded(uint256 dataSetId, uint256 firstAdded, (bytes)[] pieceData, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) PiecesAdded(dataSetId *big.Int, firstAdded *big.Int, pieceData []CidsCid, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.PiecesAdded(&_FilecoinWarmStorageService.TransactOpts, dataSetId, firstAdded, pieceData, extraData)
+}
+
+// PiecesScheduledRemove is a paid mutator transaction binding the contract method 0xe7954aa7.
+//
+// Solidity: function piecesScheduledRemove(uint256 dataSetId, uint256[] pieceIds, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) PiecesScheduledRemove(opts *bind.TransactOpts, dataSetId *big.Int, pieceIds []*big.Int, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "piecesScheduledRemove", dataSetId, pieceIds, extraData)
+}
+
+// PiecesScheduledRemove is a paid mutator transaction binding the contract method 0xe7954aa7.
+//
+// Solidity: function piecesScheduledRemove(uint256 dataSetId, uint256[] pieceIds, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) PiecesScheduledRemove(dataSetId *big.Int, pieceIds []*big.Int, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.PiecesScheduledRemove(&_FilecoinWarmStorageService.TransactOpts, dataSetId, pieceIds, extraData)
+}
+
+// PiecesScheduledRemove is a paid mutator transaction binding the contract method 0xe7954aa7.
+//
+// Solidity: function piecesScheduledRemove(uint256 dataSetId, uint256[] pieceIds, bytes extraData) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) PiecesScheduledRemove(dataSetId *big.Int, pieceIds []*big.Int, extraData []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.PiecesScheduledRemove(&_FilecoinWarmStorageService.TransactOpts, dataSetId, pieceIds, extraData)
+}
+
+// PossessionProven is a paid mutator transaction binding the contract method 0x356de02b.
+//
+// Solidity: function possessionProven(uint256 dataSetId, uint256 , uint256 , uint256 challengeCount) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) PossessionProven(opts *bind.TransactOpts, dataSetId *big.Int, arg1 *big.Int, arg2 *big.Int, challengeCount *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "possessionProven", dataSetId, arg1, arg2, challengeCount)
+}
+
+// PossessionProven is a paid mutator transaction binding the contract method 0x356de02b.
+//
+// Solidity: function possessionProven(uint256 dataSetId, uint256 , uint256 , uint256 challengeCount) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) PossessionProven(dataSetId *big.Int, arg1 *big.Int, arg2 *big.Int, challengeCount *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.PossessionProven(&_FilecoinWarmStorageService.TransactOpts, dataSetId, arg1, arg2, challengeCount)
+}
+
+// PossessionProven is a paid mutator transaction binding the contract method 0x356de02b.
+//
+// Solidity: function possessionProven(uint256 dataSetId, uint256 , uint256 , uint256 challengeCount) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) PossessionProven(dataSetId *big.Int, arg1 *big.Int, arg2 *big.Int, challengeCount *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.PossessionProven(&_FilecoinWarmStorageService.TransactOpts, dataSetId, arg1, arg2, challengeCount)
+}
+
+// RailTerminated is a paid mutator transaction binding the contract method 0xc5153f70.
+//
+// Solidity: function railTerminated(uint256 railId, address terminator, uint256 endEpoch) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) RailTerminated(opts *bind.TransactOpts, railId *big.Int, terminator common.Address, endEpoch *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "railTerminated", railId, terminator, endEpoch)
+}
+
+// RailTerminated is a paid mutator transaction binding the contract method 0xc5153f70.
+//
+// Solidity: function railTerminated(uint256 railId, address terminator, uint256 endEpoch) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) RailTerminated(railId *big.Int, terminator common.Address, endEpoch *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.RailTerminated(&_FilecoinWarmStorageService.TransactOpts, railId, terminator, endEpoch)
+}
+
+// RailTerminated is a paid mutator transaction binding the contract method 0xc5153f70.
+//
+// Solidity: function railTerminated(uint256 railId, address terminator, uint256 endEpoch) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) RailTerminated(railId *big.Int, terminator common.Address, endEpoch *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.RailTerminated(&_FilecoinWarmStorageService.TransactOpts, railId, terminator, endEpoch)
+}
+
+// RemoveApprovedProvider is a paid mutator transaction binding the contract method 0x5840b83d.
+//
+// Solidity: function removeApprovedProvider(uint256 providerId, uint256 index) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) RemoveApprovedProvider(opts *bind.TransactOpts, providerId *big.Int, index *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "removeApprovedProvider", providerId, index)
+}
+
+// RemoveApprovedProvider is a paid mutator transaction binding the contract method 0x5840b83d.
+//
+// Solidity: function removeApprovedProvider(uint256 providerId, uint256 index) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) RemoveApprovedProvider(providerId *big.Int, index *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.RemoveApprovedProvider(&_FilecoinWarmStorageService.TransactOpts, providerId, index)
+}
+
+// RemoveApprovedProvider is a paid mutator transaction binding the contract method 0x5840b83d.
+//
+// Solidity: function removeApprovedProvider(uint256 providerId, uint256 index) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) RemoveApprovedProvider(providerId *big.Int, index *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.RemoveApprovedProvider(&_FilecoinWarmStorageService.TransactOpts, providerId, index)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) RenounceOwnership() (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.RenounceOwnership(&_FilecoinWarmStorageService.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.RenounceOwnership(&_FilecoinWarmStorageService.TransactOpts)
+}
+
+// SetViewContract is a paid mutator transaction binding the contract method 0x7f6330a1.
+//
+// Solidity: function setViewContract(address _viewContract) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) SetViewContract(opts *bind.TransactOpts, _viewContract common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "setViewContract", _viewContract)
+}
+
+// SetViewContract is a paid mutator transaction binding the contract method 0x7f6330a1.
+//
+// Solidity: function setViewContract(address _viewContract) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) SetViewContract(_viewContract common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.SetViewContract(&_FilecoinWarmStorageService.TransactOpts, _viewContract)
+}
+
+// SetViewContract is a paid mutator transaction binding the contract method 0x7f6330a1.
+//
+// Solidity: function setViewContract(address _viewContract) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) SetViewContract(_viewContract common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.SetViewContract(&_FilecoinWarmStorageService.TransactOpts, _viewContract)
+}
+
+// StorageProviderChanged is a paid mutator transaction binding the contract method 0x4059b6d7.
+//
+// Solidity: function storageProviderChanged(uint256 dataSetId, address oldServiceProvider, address newServiceProvider, bytes ) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) StorageProviderChanged(opts *bind.TransactOpts, dataSetId *big.Int, oldServiceProvider common.Address, newServiceProvider common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "storageProviderChanged", dataSetId, oldServiceProvider, newServiceProvider, arg3)
+}
+
+// StorageProviderChanged is a paid mutator transaction binding the contract method 0x4059b6d7.
+//
+// Solidity: function storageProviderChanged(uint256 dataSetId, address oldServiceProvider, address newServiceProvider, bytes ) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) StorageProviderChanged(dataSetId *big.Int, oldServiceProvider common.Address, newServiceProvider common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.StorageProviderChanged(&_FilecoinWarmStorageService.TransactOpts, dataSetId, oldServiceProvider, newServiceProvider, arg3)
+}
+
+// StorageProviderChanged is a paid mutator transaction binding the contract method 0x4059b6d7.
+//
+// Solidity: function storageProviderChanged(uint256 dataSetId, address oldServiceProvider, address newServiceProvider, bytes ) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) StorageProviderChanged(dataSetId *big.Int, oldServiceProvider common.Address, newServiceProvider common.Address, arg3 []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.StorageProviderChanged(&_FilecoinWarmStorageService.TransactOpts, dataSetId, oldServiceProvider, newServiceProvider, arg3)
+}
+
+// TerminateCDNService is a paid mutator transaction binding the contract method 0x648564c0.
+//
+// Solidity: function terminateCDNService(uint256 dataSetId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) TerminateCDNService(opts *bind.TransactOpts, dataSetId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "terminateCDNService", dataSetId)
+}
+
+// TerminateCDNService is a paid mutator transaction binding the contract method 0x648564c0.
+//
+// Solidity: function terminateCDNService(uint256 dataSetId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) TerminateCDNService(dataSetId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.TerminateCDNService(&_FilecoinWarmStorageService.TransactOpts, dataSetId)
+}
+
+// TerminateCDNService is a paid mutator transaction binding the contract method 0x648564c0.
+//
+// Solidity: function terminateCDNService(uint256 dataSetId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) TerminateCDNService(dataSetId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.TerminateCDNService(&_FilecoinWarmStorageService.TransactOpts, dataSetId)
+}
+
+// TerminateService is a paid mutator transaction binding the contract method 0xb997a71e.
+//
+// Solidity: function terminateService(uint256 dataSetId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) TerminateService(opts *bind.TransactOpts, dataSetId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "terminateService", dataSetId)
+}
+
+// TerminateService is a paid mutator transaction binding the contract method 0xb997a71e.
+//
+// Solidity: function terminateService(uint256 dataSetId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) TerminateService(dataSetId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.TerminateService(&_FilecoinWarmStorageService.TransactOpts, dataSetId)
+}
+
+// TerminateService is a paid mutator transaction binding the contract method 0xb997a71e.
+//
+// Solidity: function terminateService(uint256 dataSetId) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) TerminateService(dataSetId *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.TerminateService(&_FilecoinWarmStorageService.TransactOpts, dataSetId)
+}
+
+// TransferFilCDNController is a paid mutator transaction binding the contract method 0xf2d2929c.
+//
+// Solidity: function transferFilCDNController(address newController) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) TransferFilCDNController(opts *bind.TransactOpts, newController common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "transferFilCDNController", newController)
+}
+
+// TransferFilCDNController is a paid mutator transaction binding the contract method 0xf2d2929c.
+//
+// Solidity: function transferFilCDNController(address newController) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) TransferFilCDNController(newController common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.TransferFilCDNController(&_FilecoinWarmStorageService.TransactOpts, newController)
+}
+
+// TransferFilCDNController is a paid mutator transaction binding the contract method 0xf2d2929c.
+//
+// Solidity: function transferFilCDNController(address newController) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) TransferFilCDNController(newController common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.TransferFilCDNController(&_FilecoinWarmStorageService.TransactOpts, newController)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.TransferOwnership(&_FilecoinWarmStorageService.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.TransferOwnership(&_FilecoinWarmStorageService.TransactOpts, newOwner)
+}
+
+// UpdateServiceCommission is a paid mutator transaction binding the contract method 0x662ed4b6.
+//
+// Solidity: function updateServiceCommission(uint256 newCommissionBps) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) UpdateServiceCommission(opts *bind.TransactOpts, newCommissionBps *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "updateServiceCommission", newCommissionBps)
+}
+
+// UpdateServiceCommission is a paid mutator transaction binding the contract method 0x662ed4b6.
+//
+// Solidity: function updateServiceCommission(uint256 newCommissionBps) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) UpdateServiceCommission(newCommissionBps *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.UpdateServiceCommission(&_FilecoinWarmStorageService.TransactOpts, newCommissionBps)
+}
+
+// UpdateServiceCommission is a paid mutator transaction binding the contract method 0x662ed4b6.
+//
+// Solidity: function updateServiceCommission(uint256 newCommissionBps) returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) UpdateServiceCommission(newCommissionBps *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.UpdateServiceCommission(&_FilecoinWarmStorageService.TransactOpts, newCommissionBps)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.UpgradeToAndCall(&_FilecoinWarmStorageService.TransactOpts, newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.UpgradeToAndCall(&_FilecoinWarmStorageService.TransactOpts, newImplementation, data)
+}
+
+// ValidatePayment is a paid mutator transaction binding the contract method 0x1a7bf46f.
+//
+// Solidity: function validatePayment(uint256 railId, uint256 proposedAmount, uint256 fromEpoch, uint256 toEpoch, uint256 ) returns((uint256,uint256,string) result)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactor) ValidatePayment(opts *bind.TransactOpts, railId *big.Int, proposedAmount *big.Int, fromEpoch *big.Int, toEpoch *big.Int, arg4 *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.contract.Transact(opts, "validatePayment", railId, proposedAmount, fromEpoch, toEpoch, arg4)
+}
+
+// ValidatePayment is a paid mutator transaction binding the contract method 0x1a7bf46f.
+//
+// Solidity: function validatePayment(uint256 railId, uint256 proposedAmount, uint256 fromEpoch, uint256 toEpoch, uint256 ) returns((uint256,uint256,string) result)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceSession) ValidatePayment(railId *big.Int, proposedAmount *big.Int, fromEpoch *big.Int, toEpoch *big.Int, arg4 *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.ValidatePayment(&_FilecoinWarmStorageService.TransactOpts, railId, proposedAmount, fromEpoch, toEpoch, arg4)
+}
+
+// ValidatePayment is a paid mutator transaction binding the contract method 0x1a7bf46f.
+//
+// Solidity: function validatePayment(uint256 railId, uint256 proposedAmount, uint256 fromEpoch, uint256 toEpoch, uint256 ) returns((uint256,uint256,string) result)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceTransactorSession) ValidatePayment(railId *big.Int, proposedAmount *big.Int, fromEpoch *big.Int, toEpoch *big.Int, arg4 *big.Int) (*types.Transaction, error) {
+	return _FilecoinWarmStorageService.Contract.ValidatePayment(&_FilecoinWarmStorageService.TransactOpts, railId, proposedAmount, fromEpoch, toEpoch, arg4)
+}
+
+// FilecoinWarmStorageServiceCDNPaymentTerminatedIterator is returned from FilterCDNPaymentTerminated and is used to iterate over the raw logs and unpacked data for CDNPaymentTerminated events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceCDNPaymentTerminatedIterator struct {
+	Event *FilecoinWarmStorageServiceCDNPaymentTerminated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceCDNPaymentTerminatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceCDNPaymentTerminated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceCDNPaymentTerminated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceCDNPaymentTerminatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceCDNPaymentTerminatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceCDNPaymentTerminated represents a CDNPaymentTerminated event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceCDNPaymentTerminated struct {
+	DataSetId       *big.Int
+	EndEpoch        *big.Int
+	CacheMissRailId *big.Int
+	CdnRailId       *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterCDNPaymentTerminated is a free log retrieval operation binding the contract event 0xe8ae13ddeff1f075e7621cd59b2672919372cc6a0f69198a5eb5af0e42294a80.
+//
+// Solidity: event CDNPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterCDNPaymentTerminated(opts *bind.FilterOpts, dataSetId []*big.Int) (*FilecoinWarmStorageServiceCDNPaymentTerminatedIterator, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "CDNPaymentTerminated", dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceCDNPaymentTerminatedIterator{contract: _FilecoinWarmStorageService.contract, event: "CDNPaymentTerminated", logs: logs, sub: sub}, nil
+}
+
+// WatchCDNPaymentTerminated is a free log subscription operation binding the contract event 0xe8ae13ddeff1f075e7621cd59b2672919372cc6a0f69198a5eb5af0e42294a80.
+//
+// Solidity: event CDNPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchCDNPaymentTerminated(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceCDNPaymentTerminated, dataSetId []*big.Int) (event.Subscription, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "CDNPaymentTerminated", dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceCDNPaymentTerminated)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "CDNPaymentTerminated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseCDNPaymentTerminated is a log parse operation binding the contract event 0xe8ae13ddeff1f075e7621cd59b2672919372cc6a0f69198a5eb5af0e42294a80.
+//
+// Solidity: event CDNPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseCDNPaymentTerminated(log types.Log) (*FilecoinWarmStorageServiceCDNPaymentTerminated, error) {
+	event := new(FilecoinWarmStorageServiceCDNPaymentTerminated)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "CDNPaymentTerminated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceCDNServiceTerminatedIterator is returned from FilterCDNServiceTerminated and is used to iterate over the raw logs and unpacked data for CDNServiceTerminated events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceCDNServiceTerminatedIterator struct {
+	Event *FilecoinWarmStorageServiceCDNServiceTerminated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceCDNServiceTerminatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceCDNServiceTerminated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceCDNServiceTerminated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceCDNServiceTerminatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceCDNServiceTerminatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceCDNServiceTerminated represents a CDNServiceTerminated event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceCDNServiceTerminated struct {
+	Caller          common.Address
+	DataSetId       *big.Int
+	CacheMissRailId *big.Int
+	CdnRailId       *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterCDNServiceTerminated is a free log retrieval operation binding the contract event 0xe050575f2f51273412c3b1a9a74ce3a2abc98172b48f6d19442de80a3744367d.
+//
+// Solidity: event CDNServiceTerminated(address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterCDNServiceTerminated(opts *bind.FilterOpts, caller []common.Address, dataSetId []*big.Int) (*FilecoinWarmStorageServiceCDNServiceTerminatedIterator, error) {
+
+	var callerRule []interface{}
+	for _, callerItem := range caller {
+		callerRule = append(callerRule, callerItem)
+	}
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "CDNServiceTerminated", callerRule, dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceCDNServiceTerminatedIterator{contract: _FilecoinWarmStorageService.contract, event: "CDNServiceTerminated", logs: logs, sub: sub}, nil
+}
+
+// WatchCDNServiceTerminated is a free log subscription operation binding the contract event 0xe050575f2f51273412c3b1a9a74ce3a2abc98172b48f6d19442de80a3744367d.
+//
+// Solidity: event CDNServiceTerminated(address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchCDNServiceTerminated(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceCDNServiceTerminated, caller []common.Address, dataSetId []*big.Int) (event.Subscription, error) {
+
+	var callerRule []interface{}
+	for _, callerItem := range caller {
+		callerRule = append(callerRule, callerItem)
+	}
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "CDNServiceTerminated", callerRule, dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceCDNServiceTerminated)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "CDNServiceTerminated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseCDNServiceTerminated is a log parse operation binding the contract event 0xe050575f2f51273412c3b1a9a74ce3a2abc98172b48f6d19442de80a3744367d.
+//
+// Solidity: event CDNServiceTerminated(address indexed caller, uint256 indexed dataSetId, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseCDNServiceTerminated(log types.Log) (*FilecoinWarmStorageServiceCDNServiceTerminated, error) {
+	event := new(FilecoinWarmStorageServiceCDNServiceTerminated)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "CDNServiceTerminated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceContractUpgradedIterator is returned from FilterContractUpgraded and is used to iterate over the raw logs and unpacked data for ContractUpgraded events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceContractUpgradedIterator struct {
+	Event *FilecoinWarmStorageServiceContractUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceContractUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceContractUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceContractUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceContractUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceContractUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceContractUpgraded represents a ContractUpgraded event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceContractUpgraded struct {
+	Version        string
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterContractUpgraded is a free log retrieval operation binding the contract event 0x2b51ff7c4cc8e6fe1c72e9d9685b7d2a88a5d82ad3a644afbdceb0272c89c1c3.
+//
+// Solidity: event ContractUpgraded(string version, address implementation)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterContractUpgraded(opts *bind.FilterOpts) (*FilecoinWarmStorageServiceContractUpgradedIterator, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "ContractUpgraded")
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceContractUpgradedIterator{contract: _FilecoinWarmStorageService.contract, event: "ContractUpgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchContractUpgraded is a free log subscription operation binding the contract event 0x2b51ff7c4cc8e6fe1c72e9d9685b7d2a88a5d82ad3a644afbdceb0272c89c1c3.
+//
+// Solidity: event ContractUpgraded(string version, address implementation)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchContractUpgraded(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceContractUpgraded) (event.Subscription, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "ContractUpgraded")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceContractUpgraded)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ContractUpgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseContractUpgraded is a log parse operation binding the contract event 0x2b51ff7c4cc8e6fe1c72e9d9685b7d2a88a5d82ad3a644afbdceb0272c89c1c3.
+//
+// Solidity: event ContractUpgraded(string version, address implementation)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseContractUpgraded(log types.Log) (*FilecoinWarmStorageServiceContractUpgraded, error) {
+	event := new(FilecoinWarmStorageServiceContractUpgraded)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ContractUpgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceDataSetCreatedIterator is returned from FilterDataSetCreated and is used to iterate over the raw logs and unpacked data for DataSetCreated events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceDataSetCreatedIterator struct {
+	Event *FilecoinWarmStorageServiceDataSetCreated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceDataSetCreatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceDataSetCreated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceDataSetCreated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceDataSetCreatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceDataSetCreatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceDataSetCreated represents a DataSetCreated event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceDataSetCreated struct {
+	DataSetId       *big.Int
+	ProviderId      *big.Int
+	PdpRailId       *big.Int
+	CacheMissRailId *big.Int
+	CdnRailId       *big.Int
+	Payer           common.Address
+	ServiceProvider common.Address
+	Payee           common.Address
+	MetadataKeys    []string
+	MetadataValues  []string
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterDataSetCreated is a free log retrieval operation binding the contract event 0xc90cb3863281dc6e2e16e74064ed2e0ab91144ccfe5c3492b8c33f58fe90d0db.
+//
+// Solidity: event DataSetCreated(uint256 indexed dataSetId, uint256 indexed providerId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId, address payer, address serviceProvider, address payee, string[] metadataKeys, string[] metadataValues)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterDataSetCreated(opts *bind.FilterOpts, dataSetId []*big.Int, providerId []*big.Int) (*FilecoinWarmStorageServiceDataSetCreatedIterator, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "DataSetCreated", dataSetIdRule, providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceDataSetCreatedIterator{contract: _FilecoinWarmStorageService.contract, event: "DataSetCreated", logs: logs, sub: sub}, nil
+}
+
+// WatchDataSetCreated is a free log subscription operation binding the contract event 0xc90cb3863281dc6e2e16e74064ed2e0ab91144ccfe5c3492b8c33f58fe90d0db.
+//
+// Solidity: event DataSetCreated(uint256 indexed dataSetId, uint256 indexed providerId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId, address payer, address serviceProvider, address payee, string[] metadataKeys, string[] metadataValues)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchDataSetCreated(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceDataSetCreated, dataSetId []*big.Int, providerId []*big.Int) (event.Subscription, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "DataSetCreated", dataSetIdRule, providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceDataSetCreated)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "DataSetCreated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDataSetCreated is a log parse operation binding the contract event 0xc90cb3863281dc6e2e16e74064ed2e0ab91144ccfe5c3492b8c33f58fe90d0db.
+//
+// Solidity: event DataSetCreated(uint256 indexed dataSetId, uint256 indexed providerId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId, address payer, address serviceProvider, address payee, string[] metadataKeys, string[] metadataValues)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseDataSetCreated(log types.Log) (*FilecoinWarmStorageServiceDataSetCreated, error) {
+	event := new(FilecoinWarmStorageServiceDataSetCreated)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "DataSetCreated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceDataSetServiceProviderChangedIterator is returned from FilterDataSetServiceProviderChanged and is used to iterate over the raw logs and unpacked data for DataSetServiceProviderChanged events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceDataSetServiceProviderChangedIterator struct {
+	Event *FilecoinWarmStorageServiceDataSetServiceProviderChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceDataSetServiceProviderChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceDataSetServiceProviderChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceDataSetServiceProviderChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceDataSetServiceProviderChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceDataSetServiceProviderChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceDataSetServiceProviderChanged represents a DataSetServiceProviderChanged event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceDataSetServiceProviderChanged struct {
+	DataSetId          *big.Int
+	OldServiceProvider common.Address
+	NewServiceProvider common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterDataSetServiceProviderChanged is a free log retrieval operation binding the contract event 0x6bf4c2a87885bf6d2d69480d1835a60db52c95621e8b958542cfcdc1350ea991.
+//
+// Solidity: event DataSetServiceProviderChanged(uint256 indexed dataSetId, address indexed oldServiceProvider, address indexed newServiceProvider)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterDataSetServiceProviderChanged(opts *bind.FilterOpts, dataSetId []*big.Int, oldServiceProvider []common.Address, newServiceProvider []common.Address) (*FilecoinWarmStorageServiceDataSetServiceProviderChangedIterator, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+	var oldServiceProviderRule []interface{}
+	for _, oldServiceProviderItem := range oldServiceProvider {
+		oldServiceProviderRule = append(oldServiceProviderRule, oldServiceProviderItem)
+	}
+	var newServiceProviderRule []interface{}
+	for _, newServiceProviderItem := range newServiceProvider {
+		newServiceProviderRule = append(newServiceProviderRule, newServiceProviderItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "DataSetServiceProviderChanged", dataSetIdRule, oldServiceProviderRule, newServiceProviderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceDataSetServiceProviderChangedIterator{contract: _FilecoinWarmStorageService.contract, event: "DataSetServiceProviderChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchDataSetServiceProviderChanged is a free log subscription operation binding the contract event 0x6bf4c2a87885bf6d2d69480d1835a60db52c95621e8b958542cfcdc1350ea991.
+//
+// Solidity: event DataSetServiceProviderChanged(uint256 indexed dataSetId, address indexed oldServiceProvider, address indexed newServiceProvider)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchDataSetServiceProviderChanged(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceDataSetServiceProviderChanged, dataSetId []*big.Int, oldServiceProvider []common.Address, newServiceProvider []common.Address) (event.Subscription, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+	var oldServiceProviderRule []interface{}
+	for _, oldServiceProviderItem := range oldServiceProvider {
+		oldServiceProviderRule = append(oldServiceProviderRule, oldServiceProviderItem)
+	}
+	var newServiceProviderRule []interface{}
+	for _, newServiceProviderItem := range newServiceProvider {
+		newServiceProviderRule = append(newServiceProviderRule, newServiceProviderItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "DataSetServiceProviderChanged", dataSetIdRule, oldServiceProviderRule, newServiceProviderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceDataSetServiceProviderChanged)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "DataSetServiceProviderChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDataSetServiceProviderChanged is a log parse operation binding the contract event 0x6bf4c2a87885bf6d2d69480d1835a60db52c95621e8b958542cfcdc1350ea991.
+//
+// Solidity: event DataSetServiceProviderChanged(uint256 indexed dataSetId, address indexed oldServiceProvider, address indexed newServiceProvider)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseDataSetServiceProviderChanged(log types.Log) (*FilecoinWarmStorageServiceDataSetServiceProviderChanged, error) {
+	event := new(FilecoinWarmStorageServiceDataSetServiceProviderChanged)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "DataSetServiceProviderChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceEIP712DomainChangedIterator is returned from FilterEIP712DomainChanged and is used to iterate over the raw logs and unpacked data for EIP712DomainChanged events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceEIP712DomainChangedIterator struct {
+	Event *FilecoinWarmStorageServiceEIP712DomainChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceEIP712DomainChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceEIP712DomainChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceEIP712DomainChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceEIP712DomainChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceEIP712DomainChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceEIP712DomainChanged represents a EIP712DomainChanged event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceEIP712DomainChanged struct {
+	Raw types.Log // Blockchain specific contextual infos
+}
+
+// FilterEIP712DomainChanged is a free log retrieval operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterEIP712DomainChanged(opts *bind.FilterOpts) (*FilecoinWarmStorageServiceEIP712DomainChangedIterator, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "EIP712DomainChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceEIP712DomainChangedIterator{contract: _FilecoinWarmStorageService.contract, event: "EIP712DomainChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchEIP712DomainChanged is a free log subscription operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchEIP712DomainChanged(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceEIP712DomainChanged) (event.Subscription, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "EIP712DomainChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceEIP712DomainChanged)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "EIP712DomainChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEIP712DomainChanged is a log parse operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseEIP712DomainChanged(log types.Log) (*FilecoinWarmStorageServiceEIP712DomainChanged, error) {
+	event := new(FilecoinWarmStorageServiceEIP712DomainChanged)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "EIP712DomainChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceFaultRecordIterator is returned from FilterFaultRecord and is used to iterate over the raw logs and unpacked data for FaultRecord events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceFaultRecordIterator struct {
+	Event *FilecoinWarmStorageServiceFaultRecord // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceFaultRecordIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceFaultRecord)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceFaultRecord)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceFaultRecordIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceFaultRecordIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceFaultRecord represents a FaultRecord event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceFaultRecord struct {
+	DataSetId      *big.Int
+	PeriodsFaulted *big.Int
+	Deadline       *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterFaultRecord is a free log retrieval operation binding the contract event 0xff5f076c63706be9f7eaafa8329db4a9ce9b9e3cd6e53470f05491e2043e1a81.
+//
+// Solidity: event FaultRecord(uint256 indexed dataSetId, uint256 periodsFaulted, uint256 deadline)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterFaultRecord(opts *bind.FilterOpts, dataSetId []*big.Int) (*FilecoinWarmStorageServiceFaultRecordIterator, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "FaultRecord", dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceFaultRecordIterator{contract: _FilecoinWarmStorageService.contract, event: "FaultRecord", logs: logs, sub: sub}, nil
+}
+
+// WatchFaultRecord is a free log subscription operation binding the contract event 0xff5f076c63706be9f7eaafa8329db4a9ce9b9e3cd6e53470f05491e2043e1a81.
+//
+// Solidity: event FaultRecord(uint256 indexed dataSetId, uint256 periodsFaulted, uint256 deadline)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchFaultRecord(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceFaultRecord, dataSetId []*big.Int) (event.Subscription, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "FaultRecord", dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceFaultRecord)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "FaultRecord", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFaultRecord is a log parse operation binding the contract event 0xff5f076c63706be9f7eaafa8329db4a9ce9b9e3cd6e53470f05491e2043e1a81.
+//
+// Solidity: event FaultRecord(uint256 indexed dataSetId, uint256 periodsFaulted, uint256 deadline)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseFaultRecord(log types.Log) (*FilecoinWarmStorageServiceFaultRecord, error) {
+	event := new(FilecoinWarmStorageServiceFaultRecord)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "FaultRecord", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceFilCDNControllerChangedIterator is returned from FilterFilCDNControllerChanged and is used to iterate over the raw logs and unpacked data for FilCDNControllerChanged events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceFilCDNControllerChangedIterator struct {
+	Event *FilecoinWarmStorageServiceFilCDNControllerChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceFilCDNControllerChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceFilCDNControllerChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceFilCDNControllerChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceFilCDNControllerChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceFilCDNControllerChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceFilCDNControllerChanged represents a FilCDNControllerChanged event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceFilCDNControllerChanged struct {
+	OldController common.Address
+	NewController common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterFilCDNControllerChanged is a free log retrieval operation binding the contract event 0x6f341bfc927682055fb27cdbac00d0a93e8b4b8af0f6e42e1da36e63f45a03f6.
+//
+// Solidity: event FilCDNControllerChanged(address oldController, address newController)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterFilCDNControllerChanged(opts *bind.FilterOpts) (*FilecoinWarmStorageServiceFilCDNControllerChangedIterator, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "FilCDNControllerChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceFilCDNControllerChangedIterator{contract: _FilecoinWarmStorageService.contract, event: "FilCDNControllerChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchFilCDNControllerChanged is a free log subscription operation binding the contract event 0x6f341bfc927682055fb27cdbac00d0a93e8b4b8af0f6e42e1da36e63f45a03f6.
+//
+// Solidity: event FilCDNControllerChanged(address oldController, address newController)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchFilCDNControllerChanged(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceFilCDNControllerChanged) (event.Subscription, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "FilCDNControllerChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceFilCDNControllerChanged)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "FilCDNControllerChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFilCDNControllerChanged is a log parse operation binding the contract event 0x6f341bfc927682055fb27cdbac00d0a93e8b4b8af0f6e42e1da36e63f45a03f6.
+//
+// Solidity: event FilCDNControllerChanged(address oldController, address newController)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseFilCDNControllerChanged(log types.Log) (*FilecoinWarmStorageServiceFilCDNControllerChanged, error) {
+	event := new(FilecoinWarmStorageServiceFilCDNControllerChanged)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "FilCDNControllerChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceFilecoinServiceDeployedIterator is returned from FilterFilecoinServiceDeployed and is used to iterate over the raw logs and unpacked data for FilecoinServiceDeployed events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceFilecoinServiceDeployedIterator struct {
+	Event *FilecoinWarmStorageServiceFilecoinServiceDeployed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceFilecoinServiceDeployedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceFilecoinServiceDeployed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceFilecoinServiceDeployed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceFilecoinServiceDeployedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceFilecoinServiceDeployedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceFilecoinServiceDeployed represents a FilecoinServiceDeployed event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceFilecoinServiceDeployed struct {
+	Name        string
+	Description string
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterFilecoinServiceDeployed is a free log retrieval operation binding the contract event 0x139babbfe1492fc231f36f2d6e0e2ca503f8c9ebb0c641cffa70facd2ec2e2df.
+//
+// Solidity: event FilecoinServiceDeployed(string name, string description)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterFilecoinServiceDeployed(opts *bind.FilterOpts) (*FilecoinWarmStorageServiceFilecoinServiceDeployedIterator, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "FilecoinServiceDeployed")
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceFilecoinServiceDeployedIterator{contract: _FilecoinWarmStorageService.contract, event: "FilecoinServiceDeployed", logs: logs, sub: sub}, nil
+}
+
+// WatchFilecoinServiceDeployed is a free log subscription operation binding the contract event 0x139babbfe1492fc231f36f2d6e0e2ca503f8c9ebb0c641cffa70facd2ec2e2df.
+//
+// Solidity: event FilecoinServiceDeployed(string name, string description)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchFilecoinServiceDeployed(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceFilecoinServiceDeployed) (event.Subscription, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "FilecoinServiceDeployed")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceFilecoinServiceDeployed)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "FilecoinServiceDeployed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFilecoinServiceDeployed is a log parse operation binding the contract event 0x139babbfe1492fc231f36f2d6e0e2ca503f8c9ebb0c641cffa70facd2ec2e2df.
+//
+// Solidity: event FilecoinServiceDeployed(string name, string description)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseFilecoinServiceDeployed(log types.Log) (*FilecoinWarmStorageServiceFilecoinServiceDeployed, error) {
+	event := new(FilecoinWarmStorageServiceFilecoinServiceDeployed)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "FilecoinServiceDeployed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceInitializedIterator struct {
+	Event *FilecoinWarmStorageServiceInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceInitialized represents a Initialized event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterInitialized(opts *bind.FilterOpts) (*FilecoinWarmStorageServiceInitializedIterator, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceInitializedIterator{contract: _FilecoinWarmStorageService.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceInitialized)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseInitialized(log types.Log) (*FilecoinWarmStorageServiceInitialized, error) {
+	event := new(FilecoinWarmStorageServiceInitialized)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceOwnershipTransferredIterator struct {
+	Event *FilecoinWarmStorageServiceOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceOwnershipTransferred represents a OwnershipTransferred event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*FilecoinWarmStorageServiceOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceOwnershipTransferredIterator{contract: _FilecoinWarmStorageService.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceOwnershipTransferred)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseOwnershipTransferred(log types.Log) (*FilecoinWarmStorageServiceOwnershipTransferred, error) {
+	event := new(FilecoinWarmStorageServiceOwnershipTransferred)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServicePDPPaymentTerminatedIterator is returned from FilterPDPPaymentTerminated and is used to iterate over the raw logs and unpacked data for PDPPaymentTerminated events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServicePDPPaymentTerminatedIterator struct {
+	Event *FilecoinWarmStorageServicePDPPaymentTerminated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServicePDPPaymentTerminatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServicePDPPaymentTerminated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServicePDPPaymentTerminated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServicePDPPaymentTerminatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServicePDPPaymentTerminatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServicePDPPaymentTerminated represents a PDPPaymentTerminated event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServicePDPPaymentTerminated struct {
+	DataSetId *big.Int
+	EndEpoch  *big.Int
+	PdpRailId *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterPDPPaymentTerminated is a free log retrieval operation binding the contract event 0x15371708a8f4745aad266e85741738fc10741627fcc63fd79f29843c59bb3eaf.
+//
+// Solidity: event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterPDPPaymentTerminated(opts *bind.FilterOpts, dataSetId []*big.Int) (*FilecoinWarmStorageServicePDPPaymentTerminatedIterator, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "PDPPaymentTerminated", dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServicePDPPaymentTerminatedIterator{contract: _FilecoinWarmStorageService.contract, event: "PDPPaymentTerminated", logs: logs, sub: sub}, nil
+}
+
+// WatchPDPPaymentTerminated is a free log subscription operation binding the contract event 0x15371708a8f4745aad266e85741738fc10741627fcc63fd79f29843c59bb3eaf.
+//
+// Solidity: event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchPDPPaymentTerminated(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServicePDPPaymentTerminated, dataSetId []*big.Int) (event.Subscription, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "PDPPaymentTerminated", dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServicePDPPaymentTerminated)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "PDPPaymentTerminated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePDPPaymentTerminated is a log parse operation binding the contract event 0x15371708a8f4745aad266e85741738fc10741627fcc63fd79f29843c59bb3eaf.
+//
+// Solidity: event PDPPaymentTerminated(uint256 indexed dataSetId, uint256 endEpoch, uint256 pdpRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParsePDPPaymentTerminated(log types.Log) (*FilecoinWarmStorageServicePDPPaymentTerminated, error) {
+	event := new(FilecoinWarmStorageServicePDPPaymentTerminated)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "PDPPaymentTerminated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServicePaymentArbitratedIterator is returned from FilterPaymentArbitrated and is used to iterate over the raw logs and unpacked data for PaymentArbitrated events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServicePaymentArbitratedIterator struct {
+	Event *FilecoinWarmStorageServicePaymentArbitrated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServicePaymentArbitratedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServicePaymentArbitrated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServicePaymentArbitrated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServicePaymentArbitratedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServicePaymentArbitratedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServicePaymentArbitrated represents a PaymentArbitrated event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServicePaymentArbitrated struct {
+	RailId         *big.Int
+	DataSetId      *big.Int
+	OriginalAmount *big.Int
+	ModifiedAmount *big.Int
+	FaultedEpochs  *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaymentArbitrated is a free log retrieval operation binding the contract event 0x147d5f260d74bf88a8fbefcb61a53cf5c5f6c6a6a9c86e2b1819bdc2890458cf.
+//
+// Solidity: event PaymentArbitrated(uint256 railId, uint256 dataSetId, uint256 originalAmount, uint256 modifiedAmount, uint256 faultedEpochs)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterPaymentArbitrated(opts *bind.FilterOpts) (*FilecoinWarmStorageServicePaymentArbitratedIterator, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "PaymentArbitrated")
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServicePaymentArbitratedIterator{contract: _FilecoinWarmStorageService.contract, event: "PaymentArbitrated", logs: logs, sub: sub}, nil
+}
+
+// WatchPaymentArbitrated is a free log subscription operation binding the contract event 0x147d5f260d74bf88a8fbefcb61a53cf5c5f6c6a6a9c86e2b1819bdc2890458cf.
+//
+// Solidity: event PaymentArbitrated(uint256 railId, uint256 dataSetId, uint256 originalAmount, uint256 modifiedAmount, uint256 faultedEpochs)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchPaymentArbitrated(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServicePaymentArbitrated) (event.Subscription, error) {
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "PaymentArbitrated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServicePaymentArbitrated)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "PaymentArbitrated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaymentArbitrated is a log parse operation binding the contract event 0x147d5f260d74bf88a8fbefcb61a53cf5c5f6c6a6a9c86e2b1819bdc2890458cf.
+//
+// Solidity: event PaymentArbitrated(uint256 railId, uint256 dataSetId, uint256 originalAmount, uint256 modifiedAmount, uint256 faultedEpochs)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParsePaymentArbitrated(log types.Log) (*FilecoinWarmStorageServicePaymentArbitrated, error) {
+	event := new(FilecoinWarmStorageServicePaymentArbitrated)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "PaymentArbitrated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServicePieceAddedIterator is returned from FilterPieceAdded and is used to iterate over the raw logs and unpacked data for PieceAdded events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServicePieceAddedIterator struct {
+	Event *FilecoinWarmStorageServicePieceAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServicePieceAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServicePieceAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServicePieceAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServicePieceAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServicePieceAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServicePieceAdded represents a PieceAdded event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServicePieceAdded struct {
+	DataSetId *big.Int
+	PieceId   *big.Int
+	PieceCid  CidsCid
+	Keys      []string
+	Values    []string
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterPieceAdded is a free log retrieval operation binding the contract event 0xe919e037e2ba38e953115496aafcfc43555ef39f79c2f5f996608a78628eabd7.
+//
+// Solidity: event PieceAdded(uint256 indexed dataSetId, uint256 indexed pieceId, (bytes) pieceCid, string[] keys, string[] values)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterPieceAdded(opts *bind.FilterOpts, dataSetId []*big.Int, pieceId []*big.Int) (*FilecoinWarmStorageServicePieceAddedIterator, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+	var pieceIdRule []interface{}
+	for _, pieceIdItem := range pieceId {
+		pieceIdRule = append(pieceIdRule, pieceIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "PieceAdded", dataSetIdRule, pieceIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServicePieceAddedIterator{contract: _FilecoinWarmStorageService.contract, event: "PieceAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchPieceAdded is a free log subscription operation binding the contract event 0xe919e037e2ba38e953115496aafcfc43555ef39f79c2f5f996608a78628eabd7.
+//
+// Solidity: event PieceAdded(uint256 indexed dataSetId, uint256 indexed pieceId, (bytes) pieceCid, string[] keys, string[] values)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchPieceAdded(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServicePieceAdded, dataSetId []*big.Int, pieceId []*big.Int) (event.Subscription, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+	var pieceIdRule []interface{}
+	for _, pieceIdItem := range pieceId {
+		pieceIdRule = append(pieceIdRule, pieceIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "PieceAdded", dataSetIdRule, pieceIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServicePieceAdded)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "PieceAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePieceAdded is a log parse operation binding the contract event 0xe919e037e2ba38e953115496aafcfc43555ef39f79c2f5f996608a78628eabd7.
+//
+// Solidity: event PieceAdded(uint256 indexed dataSetId, uint256 indexed pieceId, (bytes) pieceCid, string[] keys, string[] values)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParsePieceAdded(log types.Log) (*FilecoinWarmStorageServicePieceAdded, error) {
+	event := new(FilecoinWarmStorageServicePieceAdded)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "PieceAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceProviderApprovedIterator is returned from FilterProviderApproved and is used to iterate over the raw logs and unpacked data for ProviderApproved events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceProviderApprovedIterator struct {
+	Event *FilecoinWarmStorageServiceProviderApproved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceProviderApprovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceProviderApproved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceProviderApproved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceProviderApprovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceProviderApprovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceProviderApproved represents a ProviderApproved event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceProviderApproved struct {
+	ProviderId *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderApproved is a free log retrieval operation binding the contract event 0xa58a9113199b8ca6ab27dcb19489338356a3870ca0467736c7dff7769d9d0e4b.
+//
+// Solidity: event ProviderApproved(uint256 indexed providerId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterProviderApproved(opts *bind.FilterOpts, providerId []*big.Int) (*FilecoinWarmStorageServiceProviderApprovedIterator, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "ProviderApproved", providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceProviderApprovedIterator{contract: _FilecoinWarmStorageService.contract, event: "ProviderApproved", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderApproved is a free log subscription operation binding the contract event 0xa58a9113199b8ca6ab27dcb19489338356a3870ca0467736c7dff7769d9d0e4b.
+//
+// Solidity: event ProviderApproved(uint256 indexed providerId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchProviderApproved(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceProviderApproved, providerId []*big.Int) (event.Subscription, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "ProviderApproved", providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceProviderApproved)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ProviderApproved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderApproved is a log parse operation binding the contract event 0xa58a9113199b8ca6ab27dcb19489338356a3870ca0467736c7dff7769d9d0e4b.
+//
+// Solidity: event ProviderApproved(uint256 indexed providerId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseProviderApproved(log types.Log) (*FilecoinWarmStorageServiceProviderApproved, error) {
+	event := new(FilecoinWarmStorageServiceProviderApproved)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ProviderApproved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceProviderUnapprovedIterator is returned from FilterProviderUnapproved and is used to iterate over the raw logs and unpacked data for ProviderUnapproved events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceProviderUnapprovedIterator struct {
+	Event *FilecoinWarmStorageServiceProviderUnapproved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceProviderUnapprovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceProviderUnapproved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceProviderUnapproved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceProviderUnapprovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceProviderUnapprovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceProviderUnapproved represents a ProviderUnapproved event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceProviderUnapproved struct {
+	ProviderId *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderUnapproved is a free log retrieval operation binding the contract event 0xba4e32ee0678ec258ee0a93a97d502407f44c84993025385cd10a7f565c82b24.
+//
+// Solidity: event ProviderUnapproved(uint256 indexed providerId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterProviderUnapproved(opts *bind.FilterOpts, providerId []*big.Int) (*FilecoinWarmStorageServiceProviderUnapprovedIterator, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "ProviderUnapproved", providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceProviderUnapprovedIterator{contract: _FilecoinWarmStorageService.contract, event: "ProviderUnapproved", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderUnapproved is a free log subscription operation binding the contract event 0xba4e32ee0678ec258ee0a93a97d502407f44c84993025385cd10a7f565c82b24.
+//
+// Solidity: event ProviderUnapproved(uint256 indexed providerId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchProviderUnapproved(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceProviderUnapproved, providerId []*big.Int) (event.Subscription, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "ProviderUnapproved", providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceProviderUnapproved)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ProviderUnapproved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderUnapproved is a log parse operation binding the contract event 0xba4e32ee0678ec258ee0a93a97d502407f44c84993025385cd10a7f565c82b24.
+//
+// Solidity: event ProviderUnapproved(uint256 indexed providerId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseProviderUnapproved(log types.Log) (*FilecoinWarmStorageServiceProviderUnapproved, error) {
+	event := new(FilecoinWarmStorageServiceProviderUnapproved)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ProviderUnapproved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceRailRateUpdatedIterator is returned from FilterRailRateUpdated and is used to iterate over the raw logs and unpacked data for RailRateUpdated events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceRailRateUpdatedIterator struct {
+	Event *FilecoinWarmStorageServiceRailRateUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceRailRateUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceRailRateUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceRailRateUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceRailRateUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceRailRateUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceRailRateUpdated represents a RailRateUpdated event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceRailRateUpdated struct {
+	DataSetId *big.Int
+	RailId    *big.Int
+	NewRate   *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterRailRateUpdated is a free log retrieval operation binding the contract event 0xe48d2ac923afa407ac53fd133176c8ba21d06ab27a0a79391ce837609fe19a63.
+//
+// Solidity: event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterRailRateUpdated(opts *bind.FilterOpts, dataSetId []*big.Int) (*FilecoinWarmStorageServiceRailRateUpdatedIterator, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "RailRateUpdated", dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceRailRateUpdatedIterator{contract: _FilecoinWarmStorageService.contract, event: "RailRateUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchRailRateUpdated is a free log subscription operation binding the contract event 0xe48d2ac923afa407ac53fd133176c8ba21d06ab27a0a79391ce837609fe19a63.
+//
+// Solidity: event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchRailRateUpdated(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceRailRateUpdated, dataSetId []*big.Int) (event.Subscription, error) {
+
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "RailRateUpdated", dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceRailRateUpdated)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "RailRateUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRailRateUpdated is a log parse operation binding the contract event 0xe48d2ac923afa407ac53fd133176c8ba21d06ab27a0a79391ce837609fe19a63.
+//
+// Solidity: event RailRateUpdated(uint256 indexed dataSetId, uint256 railId, uint256 newRate)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseRailRateUpdated(log types.Log) (*FilecoinWarmStorageServiceRailRateUpdated, error) {
+	event := new(FilecoinWarmStorageServiceRailRateUpdated)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "RailRateUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceServiceTerminatedIterator is returned from FilterServiceTerminated and is used to iterate over the raw logs and unpacked data for ServiceTerminated events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceServiceTerminatedIterator struct {
+	Event *FilecoinWarmStorageServiceServiceTerminated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceServiceTerminatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceServiceTerminated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceServiceTerminated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceServiceTerminatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceServiceTerminatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceServiceTerminated represents a ServiceTerminated event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceServiceTerminated struct {
+	Caller          common.Address
+	DataSetId       *big.Int
+	PdpRailId       *big.Int
+	CacheMissRailId *big.Int
+	CdnRailId       *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterServiceTerminated is a free log retrieval operation binding the contract event 0x10c867634d8e51bbfd5ddd2e06b4f4a97a91274488ee3afbe1e146aa79e85293.
+//
+// Solidity: event ServiceTerminated(address indexed caller, uint256 indexed dataSetId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterServiceTerminated(opts *bind.FilterOpts, caller []common.Address, dataSetId []*big.Int) (*FilecoinWarmStorageServiceServiceTerminatedIterator, error) {
+
+	var callerRule []interface{}
+	for _, callerItem := range caller {
+		callerRule = append(callerRule, callerItem)
+	}
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "ServiceTerminated", callerRule, dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceServiceTerminatedIterator{contract: _FilecoinWarmStorageService.contract, event: "ServiceTerminated", logs: logs, sub: sub}, nil
+}
+
+// WatchServiceTerminated is a free log subscription operation binding the contract event 0x10c867634d8e51bbfd5ddd2e06b4f4a97a91274488ee3afbe1e146aa79e85293.
+//
+// Solidity: event ServiceTerminated(address indexed caller, uint256 indexed dataSetId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchServiceTerminated(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceServiceTerminated, caller []common.Address, dataSetId []*big.Int) (event.Subscription, error) {
+
+	var callerRule []interface{}
+	for _, callerItem := range caller {
+		callerRule = append(callerRule, callerItem)
+	}
+	var dataSetIdRule []interface{}
+	for _, dataSetIdItem := range dataSetId {
+		dataSetIdRule = append(dataSetIdRule, dataSetIdItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "ServiceTerminated", callerRule, dataSetIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceServiceTerminated)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ServiceTerminated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseServiceTerminated is a log parse operation binding the contract event 0x10c867634d8e51bbfd5ddd2e06b4f4a97a91274488ee3afbe1e146aa79e85293.
+//
+// Solidity: event ServiceTerminated(address indexed caller, uint256 indexed dataSetId, uint256 pdpRailId, uint256 cacheMissRailId, uint256 cdnRailId)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseServiceTerminated(log types.Log) (*FilecoinWarmStorageServiceServiceTerminated, error) {
+	event := new(FilecoinWarmStorageServiceServiceTerminated)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ServiceTerminated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceUpgradedIterator struct {
+	Event *FilecoinWarmStorageServiceUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceUpgraded represents a Upgraded event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*FilecoinWarmStorageServiceUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceUpgradedIterator{contract: _FilecoinWarmStorageService.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceUpgraded)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseUpgraded(log types.Log) (*FilecoinWarmStorageServiceUpgraded, error) {
+	event := new(FilecoinWarmStorageServiceUpgraded)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FilecoinWarmStorageServiceViewContractSetIterator is returned from FilterViewContractSet and is used to iterate over the raw logs and unpacked data for ViewContractSet events raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceViewContractSetIterator struct {
+	Event *FilecoinWarmStorageServiceViewContractSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FilecoinWarmStorageServiceViewContractSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FilecoinWarmStorageServiceViewContractSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FilecoinWarmStorageServiceViewContractSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FilecoinWarmStorageServiceViewContractSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FilecoinWarmStorageServiceViewContractSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FilecoinWarmStorageServiceViewContractSet represents a ViewContractSet event raised by the FilecoinWarmStorageService contract.
+type FilecoinWarmStorageServiceViewContractSet struct {
+	ViewContract common.Address
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterViewContractSet is a free log retrieval operation binding the contract event 0xe25384d89f44dc828e27dcd324f63dae28a4b9e5bb164e04a9c7ecfacf01fd36.
+//
+// Solidity: event ViewContractSet(address indexed viewContract)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) FilterViewContractSet(opts *bind.FilterOpts, viewContract []common.Address) (*FilecoinWarmStorageServiceViewContractSetIterator, error) {
+
+	var viewContractRule []interface{}
+	for _, viewContractItem := range viewContract {
+		viewContractRule = append(viewContractRule, viewContractItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.FilterLogs(opts, "ViewContractSet", viewContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FilecoinWarmStorageServiceViewContractSetIterator{contract: _FilecoinWarmStorageService.contract, event: "ViewContractSet", logs: logs, sub: sub}, nil
+}
+
+// WatchViewContractSet is a free log subscription operation binding the contract event 0xe25384d89f44dc828e27dcd324f63dae28a4b9e5bb164e04a9c7ecfacf01fd36.
+//
+// Solidity: event ViewContractSet(address indexed viewContract)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) WatchViewContractSet(opts *bind.WatchOpts, sink chan<- *FilecoinWarmStorageServiceViewContractSet, viewContract []common.Address) (event.Subscription, error) {
+
+	var viewContractRule []interface{}
+	for _, viewContractItem := range viewContract {
+		viewContractRule = append(viewContractRule, viewContractItem)
+	}
+
+	logs, sub, err := _FilecoinWarmStorageService.contract.WatchLogs(opts, "ViewContractSet", viewContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FilecoinWarmStorageServiceViewContractSet)
+				if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ViewContractSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseViewContractSet is a log parse operation binding the contract event 0xe25384d89f44dc828e27dcd324f63dae28a4b9e5bb164e04a9c7ecfacf01fd36.
+//
+// Solidity: event ViewContractSet(address indexed viewContract)
+func (_FilecoinWarmStorageService *FilecoinWarmStorageServiceFilterer) ParseViewContractSet(log types.Log) (*FilecoinWarmStorageServiceViewContractSet, error) {
+	event := new(FilecoinWarmStorageServiceViewContractSet)
+	if err := _FilecoinWarmStorageService.contract.UnpackLog(event, "ViewContractSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/pkg/pdp/smartcontracts/bindings/service_provider_registry.go
+++ b/pkg/pdp/smartcontracts/bindings/service_provider_registry.go
@@ -1,0 +1,3395 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ServiceProviderRegistryServiceProviderInfoView is an auto generated low-level Go binding around an user-defined struct.
+type ServiceProviderRegistryServiceProviderInfoView struct {
+	ProviderId *big.Int
+	Info       ServiceProviderRegistryStorageServiceProviderInfo
+}
+
+// ServiceProviderRegistryStoragePDPOffering is an auto generated low-level Go binding around an user-defined struct.
+type ServiceProviderRegistryStoragePDPOffering struct {
+	ServiceURL                 string
+	MinPieceSizeInBytes        *big.Int
+	MaxPieceSizeInBytes        *big.Int
+	IpniPiece                  bool
+	IpniIpfs                   bool
+	StoragePricePerTibPerMonth *big.Int
+	MinProvingPeriodInEpochs   *big.Int
+	Location                   string
+	PaymentTokenAddress        common.Address
+}
+
+// ServiceProviderRegistryStoragePaginatedProviders is an auto generated low-level Go binding around an user-defined struct.
+type ServiceProviderRegistryStoragePaginatedProviders struct {
+	Providers []ServiceProviderRegistryStorageProviderWithProduct
+	HasMore   bool
+}
+
+// ServiceProviderRegistryStorageProviderWithProduct is an auto generated low-level Go binding around an user-defined struct.
+type ServiceProviderRegistryStorageProviderWithProduct struct {
+	ProviderId   *big.Int
+	ProviderInfo ServiceProviderRegistryStorageServiceProviderInfo
+	Product      ServiceProviderRegistryStorageServiceProduct
+}
+
+// ServiceProviderRegistryStorageServiceProduct is an auto generated low-level Go binding around an user-defined struct.
+type ServiceProviderRegistryStorageServiceProduct struct {
+	ProductType    uint8
+	ProductData    []byte
+	CapabilityKeys []string
+	IsActive       bool
+}
+
+// ServiceProviderRegistryStorageServiceProviderInfo is an auto generated low-level Go binding around an user-defined struct.
+type ServiceProviderRegistryStorageServiceProviderInfo struct {
+	ServiceProvider common.Address
+	Payee           common.Address
+	Name            string
+	Description     string
+	IsActive        bool
+}
+
+// ServiceProviderRegistryMetaData contains all meta data concerning the ServiceProviderRegistry contract.
+var ServiceProviderRegistryMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BURN_ACTOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_CAPABILITIES\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_CAPABILITY_KEY_LENGTH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"MAX_CAPABILITY_VALUE_LENGTH\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"REGISTRATION_FEE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"UPGRADE_INTERFACE_VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"VERSION\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"activeProductTypeProviderCount\",\"inputs\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"}],\"outputs\":[{\"name\":\"count\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"activeProviderCount\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"addProduct\",\"inputs\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"productData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"capabilityValues\",\"type\":\"string[]\",\"internalType\":\"string[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"addressToProviderId\",\"inputs\":[{\"name\":\"providerAddress\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"decodePDPOffering\",\"inputs\":[{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.PDPOffering\",\"components\":[{\"name\":\"serviceURL\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"minPieceSizeInBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxPieceSizeInBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"ipniPiece\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"ipniIpfs\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"storagePricePerTibPerMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minProvingPeriodInEpochs\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"location\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"paymentTokenAddress\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}]}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"eip712Domain\",\"inputs\":[],\"outputs\":[{\"name\":\"fields\",\"type\":\"bytes1\",\"internalType\":\"bytes1\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"version\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"salt\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"extensions\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"encodePDPOffering\",\"inputs\":[{\"name\":\"pdpOffering\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.PDPOffering\",\"components\":[{\"name\":\"serviceURL\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"minPieceSizeInBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxPieceSizeInBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"ipniPiece\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"ipniIpfs\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"storagePricePerTibPerMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minProvingPeriodInEpochs\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"location\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"paymentTokenAddress\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"getActiveProvidersByProductType\",\"inputs\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"offset\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"limit\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"result\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.PaginatedProviders\",\"components\":[{\"name\":\"providers\",\"type\":\"tuple[]\",\"internalType\":\"structServiceProviderRegistryStorage.ProviderWithProduct[]\",\"components\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"providerInfo\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.ServiceProviderInfo\",\"components\":[{\"name\":\"serviceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}]},{\"name\":\"product\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.ServiceProduct\",\"components\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"productData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}]}]},{\"name\":\"hasMore\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getAllActiveProviders\",\"inputs\":[{\"name\":\"offset\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"limit\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"providerIds\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"},{\"name\":\"hasMore\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNextProviderId\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getPDPService\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"pdpOffering\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.PDPOffering\",\"components\":[{\"name\":\"serviceURL\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"minPieceSizeInBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxPieceSizeInBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"ipniPiece\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"ipniIpfs\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"storagePricePerTibPerMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minProvingPeriodInEpochs\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"location\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"paymentTokenAddress\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}]},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProduct\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"}],\"outputs\":[{\"name\":\"productData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProductCapabilities\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"keys\",\"type\":\"string[]\",\"internalType\":\"string[]\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool[]\",\"internalType\":\"bool[]\"},{\"name\":\"values\",\"type\":\"string[]\",\"internalType\":\"string[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProductCapability\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"key\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"exists\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"value\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProvider\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistry.ServiceProviderInfoView\",\"components\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.ServiceProviderInfo\",\"components\":[{\"name\":\"serviceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderByAddress\",\"inputs\":[{\"name\":\"providerAddress\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistry.ServiceProviderInfoView\",\"components\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.ServiceProviderInfo\",\"components\":[{\"name\":\"serviceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}]}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderCount\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderIdByAddress\",\"inputs\":[{\"name\":\"providerAddress\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProviderPayee\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"payee\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProvidersByIds\",\"inputs\":[{\"name\":\"providerIds\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"outputs\":[{\"name\":\"providerInfos\",\"type\":\"tuple[]\",\"internalType\":\"structServiceProviderRegistry.ServiceProviderInfoView[]\",\"components\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.ServiceProviderInfo\",\"components\":[{\"name\":\"serviceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}]}]},{\"name\":\"validIds\",\"type\":\"bool[]\",\"internalType\":\"bool[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getProvidersByProductType\",\"inputs\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"offset\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"limit\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"result\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.PaginatedProviders\",\"components\":[{\"name\":\"providers\",\"type\":\"tuple[]\",\"internalType\":\"structServiceProviderRegistryStorage.ProviderWithProduct[]\",\"components\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"providerInfo\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.ServiceProviderInfo\",\"components\":[{\"name\":\"serviceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}]},{\"name\":\"product\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.ServiceProduct\",\"components\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"productData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}]}]},{\"name\":\"hasMore\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isProviderActive\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isRegisteredProvider\",\"inputs\":[{\"name\":\"provider\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"migrate\",\"inputs\":[{\"name\":\"newVersion\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"productCapabilities\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"key\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"value\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"productTypeProviderCount\",\"inputs\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"}],\"outputs\":[{\"name\":\"count\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"providerHasProduct\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"providerProducts\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"}],\"outputs\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"productData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"providers\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"serviceProvider\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"isActive\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registerProvider\",\"inputs\":[{\"name\":\"payee\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"productData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"capabilityValues\",\"type\":\"string[]\",\"internalType\":\"string[]\"}],\"outputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"removeProduct\",\"inputs\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"removeProvider\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updatePDPServiceWithCapabilities\",\"inputs\":[{\"name\":\"pdpOffering\",\"type\":\"tuple\",\"internalType\":\"structServiceProviderRegistryStorage.PDPOffering\",\"components\":[{\"name\":\"serviceURL\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"minPieceSizeInBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"maxPieceSizeInBytes\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"ipniPiece\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"ipniIpfs\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"storagePricePerTibPerMonth\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minProvingPeriodInEpochs\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"location\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"paymentTokenAddress\",\"type\":\"address\",\"internalType\":\"contractIERC20\"}]},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"capabilityValues\",\"type\":\"string[]\",\"internalType\":\"string[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateProduct\",\"inputs\":[{\"name\":\"productType\",\"type\":\"uint8\",\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"productData\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"internalType\":\"string[]\"},{\"name\":\"capabilityValues\",\"type\":\"string[]\",\"internalType\":\"string[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"updateProviderInfo\",\"inputs\":[{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"event\",\"name\":\"ContractUpgraded\",\"inputs\":[{\"name\":\"version\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"EIP712DomainChanged\",\"inputs\":[],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProductAdded\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"serviceUrl\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"serviceProvider\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"indexed\":false,\"internalType\":\"string[]\"},{\"name\":\"capabilityValues\",\"type\":\"string[]\",\"indexed\":false,\"internalType\":\"string[]\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProductRemoved\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProductUpdated\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"productType\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"enumServiceProviderRegistryStorage.ProductType\"},{\"name\":\"serviceUrl\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"serviceProvider\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"capabilityKeys\",\"type\":\"string[]\",\"indexed\":false,\"internalType\":\"string[]\"},{\"name\":\"capabilityValues\",\"type\":\"string[]\",\"indexed\":false,\"internalType\":\"string[]\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderInfoUpdated\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderRegistered\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"serviceProvider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"payee\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ProviderRemoved\",\"inputs\":[{\"name\":\"providerId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AddressEmptyCode\",\"inputs\":[{\"name\":\"target\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967InvalidImplementation\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC1967NonPayable\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"UUPSUnauthorizedCallContext\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"UUPSUnsupportedProxiableUUID\",\"inputs\":[{\"name\":\"slot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]}]",
+}
+
+// ServiceProviderRegistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use ServiceProviderRegistryMetaData.ABI instead.
+var ServiceProviderRegistryABI = ServiceProviderRegistryMetaData.ABI
+
+// ServiceProviderRegistry is an auto generated Go binding around an Ethereum contract.
+type ServiceProviderRegistry struct {
+	ServiceProviderRegistryCaller     // Read-only binding to the contract
+	ServiceProviderRegistryTransactor // Write-only binding to the contract
+	ServiceProviderRegistryFilterer   // Log filterer for contract events
+}
+
+// ServiceProviderRegistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ServiceProviderRegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ServiceProviderRegistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ServiceProviderRegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ServiceProviderRegistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ServiceProviderRegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ServiceProviderRegistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ServiceProviderRegistrySession struct {
+	Contract     *ServiceProviderRegistry // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts            // Call options to use throughout this session
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// ServiceProviderRegistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ServiceProviderRegistryCallerSession struct {
+	Contract *ServiceProviderRegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                  // Call options to use throughout this session
+}
+
+// ServiceProviderRegistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ServiceProviderRegistryTransactorSession struct {
+	Contract     *ServiceProviderRegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                  // Transaction auth options to use throughout this session
+}
+
+// ServiceProviderRegistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ServiceProviderRegistryRaw struct {
+	Contract *ServiceProviderRegistry // Generic contract binding to access the raw methods on
+}
+
+// ServiceProviderRegistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ServiceProviderRegistryCallerRaw struct {
+	Contract *ServiceProviderRegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ServiceProviderRegistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ServiceProviderRegistryTransactorRaw struct {
+	Contract *ServiceProviderRegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewServiceProviderRegistry creates a new instance of ServiceProviderRegistry, bound to a specific deployed contract.
+func NewServiceProviderRegistry(address common.Address, backend bind.ContractBackend) (*ServiceProviderRegistry, error) {
+	contract, err := bindServiceProviderRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistry{ServiceProviderRegistryCaller: ServiceProviderRegistryCaller{contract: contract}, ServiceProviderRegistryTransactor: ServiceProviderRegistryTransactor{contract: contract}, ServiceProviderRegistryFilterer: ServiceProviderRegistryFilterer{contract: contract}}, nil
+}
+
+// NewServiceProviderRegistryCaller creates a new read-only instance of ServiceProviderRegistry, bound to a specific deployed contract.
+func NewServiceProviderRegistryCaller(address common.Address, caller bind.ContractCaller) (*ServiceProviderRegistryCaller, error) {
+	contract, err := bindServiceProviderRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryCaller{contract: contract}, nil
+}
+
+// NewServiceProviderRegistryTransactor creates a new write-only instance of ServiceProviderRegistry, bound to a specific deployed contract.
+func NewServiceProviderRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*ServiceProviderRegistryTransactor, error) {
+	contract, err := bindServiceProviderRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryTransactor{contract: contract}, nil
+}
+
+// NewServiceProviderRegistryFilterer creates a new log filterer instance of ServiceProviderRegistry, bound to a specific deployed contract.
+func NewServiceProviderRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*ServiceProviderRegistryFilterer, error) {
+	contract, err := bindServiceProviderRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryFilterer{contract: contract}, nil
+}
+
+// bindServiceProviderRegistry binds a generic wrapper to an already deployed contract.
+func bindServiceProviderRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ServiceProviderRegistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ServiceProviderRegistry *ServiceProviderRegistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ServiceProviderRegistry.Contract.ServiceProviderRegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ServiceProviderRegistry *ServiceProviderRegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.ServiceProviderRegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ServiceProviderRegistry *ServiceProviderRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.ServiceProviderRegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ServiceProviderRegistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// BURNACTOR is a free data retrieval call binding the contract method 0x0a6a63f1.
+//
+// Solidity: function BURN_ACTOR() view returns(address)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) BURNACTOR(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "BURN_ACTOR")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// BURNACTOR is a free data retrieval call binding the contract method 0x0a6a63f1.
+//
+// Solidity: function BURN_ACTOR() view returns(address)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) BURNACTOR() (common.Address, error) {
+	return _ServiceProviderRegistry.Contract.BURNACTOR(&_ServiceProviderRegistry.CallOpts)
+}
+
+// BURNACTOR is a free data retrieval call binding the contract method 0x0a6a63f1.
+//
+// Solidity: function BURN_ACTOR() view returns(address)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) BURNACTOR() (common.Address, error) {
+	return _ServiceProviderRegistry.Contract.BURNACTOR(&_ServiceProviderRegistry.CallOpts)
+}
+
+// MAXCAPABILITIES is a free data retrieval call binding the contract method 0x6e36e974.
+//
+// Solidity: function MAX_CAPABILITIES() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) MAXCAPABILITIES(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "MAX_CAPABILITIES")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXCAPABILITIES is a free data retrieval call binding the contract method 0x6e36e974.
+//
+// Solidity: function MAX_CAPABILITIES() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) MAXCAPABILITIES() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.MAXCAPABILITIES(&_ServiceProviderRegistry.CallOpts)
+}
+
+// MAXCAPABILITIES is a free data retrieval call binding the contract method 0x6e36e974.
+//
+// Solidity: function MAX_CAPABILITIES() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) MAXCAPABILITIES() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.MAXCAPABILITIES(&_ServiceProviderRegistry.CallOpts)
+}
+
+// MAXCAPABILITYKEYLENGTH is a free data retrieval call binding the contract method 0x7f657567.
+//
+// Solidity: function MAX_CAPABILITY_KEY_LENGTH() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) MAXCAPABILITYKEYLENGTH(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "MAX_CAPABILITY_KEY_LENGTH")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXCAPABILITYKEYLENGTH is a free data retrieval call binding the contract method 0x7f657567.
+//
+// Solidity: function MAX_CAPABILITY_KEY_LENGTH() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) MAXCAPABILITYKEYLENGTH() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.MAXCAPABILITYKEYLENGTH(&_ServiceProviderRegistry.CallOpts)
+}
+
+// MAXCAPABILITYKEYLENGTH is a free data retrieval call binding the contract method 0x7f657567.
+//
+// Solidity: function MAX_CAPABILITY_KEY_LENGTH() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) MAXCAPABILITYKEYLENGTH() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.MAXCAPABILITYKEYLENGTH(&_ServiceProviderRegistry.CallOpts)
+}
+
+// MAXCAPABILITYVALUELENGTH is a free data retrieval call binding the contract method 0xdcea1c6f.
+//
+// Solidity: function MAX_CAPABILITY_VALUE_LENGTH() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) MAXCAPABILITYVALUELENGTH(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "MAX_CAPABILITY_VALUE_LENGTH")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAXCAPABILITYVALUELENGTH is a free data retrieval call binding the contract method 0xdcea1c6f.
+//
+// Solidity: function MAX_CAPABILITY_VALUE_LENGTH() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) MAXCAPABILITYVALUELENGTH() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.MAXCAPABILITYVALUELENGTH(&_ServiceProviderRegistry.CallOpts)
+}
+
+// MAXCAPABILITYVALUELENGTH is a free data retrieval call binding the contract method 0xdcea1c6f.
+//
+// Solidity: function MAX_CAPABILITY_VALUE_LENGTH() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) MAXCAPABILITYVALUELENGTH() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.MAXCAPABILITYVALUELENGTH(&_ServiceProviderRegistry.CallOpts)
+}
+
+// REGISTRATIONFEE is a free data retrieval call binding the contract method 0x64b4f751.
+//
+// Solidity: function REGISTRATION_FEE() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) REGISTRATIONFEE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "REGISTRATION_FEE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// REGISTRATIONFEE is a free data retrieval call binding the contract method 0x64b4f751.
+//
+// Solidity: function REGISTRATION_FEE() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) REGISTRATIONFEE() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.REGISTRATIONFEE(&_ServiceProviderRegistry.CallOpts)
+}
+
+// REGISTRATIONFEE is a free data retrieval call binding the contract method 0x64b4f751.
+//
+// Solidity: function REGISTRATION_FEE() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) REGISTRATIONFEE() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.REGISTRATIONFEE(&_ServiceProviderRegistry.CallOpts)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) UPGRADEINTERFACEVERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "UPGRADE_INTERFACE_VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _ServiceProviderRegistry.Contract.UPGRADEINTERFACEVERSION(&_ServiceProviderRegistry.CallOpts)
+}
+
+// UPGRADEINTERFACEVERSION is a free data retrieval call binding the contract method 0xad3cb1cc.
+//
+// Solidity: function UPGRADE_INTERFACE_VERSION() view returns(string)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) UPGRADEINTERFACEVERSION() (string, error) {
+	return _ServiceProviderRegistry.Contract.UPGRADEINTERFACEVERSION(&_ServiceProviderRegistry.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "VERSION")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) VERSION() (string, error) {
+	return _ServiceProviderRegistry.Contract.VERSION(&_ServiceProviderRegistry.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() view returns(string)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) VERSION() (string, error) {
+	return _ServiceProviderRegistry.Contract.VERSION(&_ServiceProviderRegistry.CallOpts)
+}
+
+// ActiveProductTypeProviderCount is a free data retrieval call binding the contract method 0x8bdc7747.
+//
+// Solidity: function activeProductTypeProviderCount(uint8 productType) view returns(uint256 count)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) ActiveProductTypeProviderCount(opts *bind.CallOpts, productType uint8) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "activeProductTypeProviderCount", productType)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ActiveProductTypeProviderCount is a free data retrieval call binding the contract method 0x8bdc7747.
+//
+// Solidity: function activeProductTypeProviderCount(uint8 productType) view returns(uint256 count)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) ActiveProductTypeProviderCount(productType uint8) (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.ActiveProductTypeProviderCount(&_ServiceProviderRegistry.CallOpts, productType)
+}
+
+// ActiveProductTypeProviderCount is a free data retrieval call binding the contract method 0x8bdc7747.
+//
+// Solidity: function activeProductTypeProviderCount(uint8 productType) view returns(uint256 count)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) ActiveProductTypeProviderCount(productType uint8) (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.ActiveProductTypeProviderCount(&_ServiceProviderRegistry.CallOpts, productType)
+}
+
+// ActiveProviderCount is a free data retrieval call binding the contract method 0xf08bbda0.
+//
+// Solidity: function activeProviderCount() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) ActiveProviderCount(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "activeProviderCount")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ActiveProviderCount is a free data retrieval call binding the contract method 0xf08bbda0.
+//
+// Solidity: function activeProviderCount() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) ActiveProviderCount() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.ActiveProviderCount(&_ServiceProviderRegistry.CallOpts)
+}
+
+// ActiveProviderCount is a free data retrieval call binding the contract method 0xf08bbda0.
+//
+// Solidity: function activeProviderCount() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) ActiveProviderCount() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.ActiveProviderCount(&_ServiceProviderRegistry.CallOpts)
+}
+
+// AddressToProviderId is a free data retrieval call binding the contract method 0xe835440e.
+//
+// Solidity: function addressToProviderId(address providerAddress) view returns(uint256 providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) AddressToProviderId(opts *bind.CallOpts, providerAddress common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "addressToProviderId", providerAddress)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// AddressToProviderId is a free data retrieval call binding the contract method 0xe835440e.
+//
+// Solidity: function addressToProviderId(address providerAddress) view returns(uint256 providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) AddressToProviderId(providerAddress common.Address) (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.AddressToProviderId(&_ServiceProviderRegistry.CallOpts, providerAddress)
+}
+
+// AddressToProviderId is a free data retrieval call binding the contract method 0xe835440e.
+//
+// Solidity: function addressToProviderId(address providerAddress) view returns(uint256 providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) AddressToProviderId(providerAddress common.Address) (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.AddressToProviderId(&_ServiceProviderRegistry.CallOpts, providerAddress)
+}
+
+// DecodePDPOffering is a free data retrieval call binding the contract method 0xdeb0e462.
+//
+// Solidity: function decodePDPOffering(bytes data) pure returns((string,uint256,uint256,bool,bool,uint256,uint256,string,address))
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) DecodePDPOffering(opts *bind.CallOpts, data []byte) (ServiceProviderRegistryStoragePDPOffering, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "decodePDPOffering", data)
+
+	if err != nil {
+		return *new(ServiceProviderRegistryStoragePDPOffering), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(ServiceProviderRegistryStoragePDPOffering)).(*ServiceProviderRegistryStoragePDPOffering)
+
+	return out0, err
+
+}
+
+// DecodePDPOffering is a free data retrieval call binding the contract method 0xdeb0e462.
+//
+// Solidity: function decodePDPOffering(bytes data) pure returns((string,uint256,uint256,bool,bool,uint256,uint256,string,address))
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) DecodePDPOffering(data []byte) (ServiceProviderRegistryStoragePDPOffering, error) {
+	return _ServiceProviderRegistry.Contract.DecodePDPOffering(&_ServiceProviderRegistry.CallOpts, data)
+}
+
+// DecodePDPOffering is a free data retrieval call binding the contract method 0xdeb0e462.
+//
+// Solidity: function decodePDPOffering(bytes data) pure returns((string,uint256,uint256,bool,bool,uint256,uint256,string,address))
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) DecodePDPOffering(data []byte) (ServiceProviderRegistryStoragePDPOffering, error) {
+	return _ServiceProviderRegistry.Contract.DecodePDPOffering(&_ServiceProviderRegistry.CallOpts, data)
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) Eip712Domain(opts *bind.CallOpts) (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "eip712Domain")
+
+	outstruct := new(struct {
+		Fields            [1]byte
+		Name              string
+		Version           string
+		ChainId           *big.Int
+		VerifyingContract common.Address
+		Salt              [32]byte
+		Extensions        []*big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Fields = *abi.ConvertType(out[0], new([1]byte)).(*[1]byte)
+	outstruct.Name = *abi.ConvertType(out[1], new(string)).(*string)
+	outstruct.Version = *abi.ConvertType(out[2], new(string)).(*string)
+	outstruct.ChainId = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.VerifyingContract = *abi.ConvertType(out[4], new(common.Address)).(*common.Address)
+	outstruct.Salt = *abi.ConvertType(out[5], new([32]byte)).(*[32]byte)
+	outstruct.Extensions = *abi.ConvertType(out[6], new([]*big.Int)).(*[]*big.Int)
+
+	return *outstruct, err
+
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) Eip712Domain() (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	return _ServiceProviderRegistry.Contract.Eip712Domain(&_ServiceProviderRegistry.CallOpts)
+}
+
+// Eip712Domain is a free data retrieval call binding the contract method 0x84b0196e.
+//
+// Solidity: function eip712Domain() view returns(bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) Eip712Domain() (struct {
+	Fields            [1]byte
+	Name              string
+	Version           string
+	ChainId           *big.Int
+	VerifyingContract common.Address
+	Salt              [32]byte
+	Extensions        []*big.Int
+}, error) {
+	return _ServiceProviderRegistry.Contract.Eip712Domain(&_ServiceProviderRegistry.CallOpts)
+}
+
+// EncodePDPOffering is a free data retrieval call binding the contract method 0x82ee4b34.
+//
+// Solidity: function encodePDPOffering((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering) pure returns(bytes)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) EncodePDPOffering(opts *bind.CallOpts, pdpOffering ServiceProviderRegistryStoragePDPOffering) ([]byte, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "encodePDPOffering", pdpOffering)
+
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]byte)).(*[]byte)
+
+	return out0, err
+
+}
+
+// EncodePDPOffering is a free data retrieval call binding the contract method 0x82ee4b34.
+//
+// Solidity: function encodePDPOffering((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering) pure returns(bytes)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) EncodePDPOffering(pdpOffering ServiceProviderRegistryStoragePDPOffering) ([]byte, error) {
+	return _ServiceProviderRegistry.Contract.EncodePDPOffering(&_ServiceProviderRegistry.CallOpts, pdpOffering)
+}
+
+// EncodePDPOffering is a free data retrieval call binding the contract method 0x82ee4b34.
+//
+// Solidity: function encodePDPOffering((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering) pure returns(bytes)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) EncodePDPOffering(pdpOffering ServiceProviderRegistryStoragePDPOffering) ([]byte, error) {
+	return _ServiceProviderRegistry.Contract.EncodePDPOffering(&_ServiceProviderRegistry.CallOpts, pdpOffering)
+}
+
+// GetActiveProvidersByProductType is a free data retrieval call binding the contract method 0x213c63b1.
+//
+// Solidity: function getActiveProvidersByProductType(uint8 productType, uint256 offset, uint256 limit) view returns(((uint256,(address,address,string,string,bool),(uint8,bytes,string[],bool))[],bool) result)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetActiveProvidersByProductType(opts *bind.CallOpts, productType uint8, offset *big.Int, limit *big.Int) (ServiceProviderRegistryStoragePaginatedProviders, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getActiveProvidersByProductType", productType, offset, limit)
+
+	if err != nil {
+		return *new(ServiceProviderRegistryStoragePaginatedProviders), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(ServiceProviderRegistryStoragePaginatedProviders)).(*ServiceProviderRegistryStoragePaginatedProviders)
+
+	return out0, err
+
+}
+
+// GetActiveProvidersByProductType is a free data retrieval call binding the contract method 0x213c63b1.
+//
+// Solidity: function getActiveProvidersByProductType(uint8 productType, uint256 offset, uint256 limit) view returns(((uint256,(address,address,string,string,bool),(uint8,bytes,string[],bool))[],bool) result)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetActiveProvidersByProductType(productType uint8, offset *big.Int, limit *big.Int) (ServiceProviderRegistryStoragePaginatedProviders, error) {
+	return _ServiceProviderRegistry.Contract.GetActiveProvidersByProductType(&_ServiceProviderRegistry.CallOpts, productType, offset, limit)
+}
+
+// GetActiveProvidersByProductType is a free data retrieval call binding the contract method 0x213c63b1.
+//
+// Solidity: function getActiveProvidersByProductType(uint8 productType, uint256 offset, uint256 limit) view returns(((uint256,(address,address,string,string,bool),(uint8,bytes,string[],bool))[],bool) result)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetActiveProvidersByProductType(productType uint8, offset *big.Int, limit *big.Int) (ServiceProviderRegistryStoragePaginatedProviders, error) {
+	return _ServiceProviderRegistry.Contract.GetActiveProvidersByProductType(&_ServiceProviderRegistry.CallOpts, productType, offset, limit)
+}
+
+// GetAllActiveProviders is a free data retrieval call binding the contract method 0x2f67c065.
+//
+// Solidity: function getAllActiveProviders(uint256 offset, uint256 limit) view returns(uint256[] providerIds, bool hasMore)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetAllActiveProviders(opts *bind.CallOpts, offset *big.Int, limit *big.Int) (struct {
+	ProviderIds []*big.Int
+	HasMore     bool
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getAllActiveProviders", offset, limit)
+
+	outstruct := new(struct {
+		ProviderIds []*big.Int
+		HasMore     bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ProviderIds = *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+	outstruct.HasMore = *abi.ConvertType(out[1], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// GetAllActiveProviders is a free data retrieval call binding the contract method 0x2f67c065.
+//
+// Solidity: function getAllActiveProviders(uint256 offset, uint256 limit) view returns(uint256[] providerIds, bool hasMore)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetAllActiveProviders(offset *big.Int, limit *big.Int) (struct {
+	ProviderIds []*big.Int
+	HasMore     bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetAllActiveProviders(&_ServiceProviderRegistry.CallOpts, offset, limit)
+}
+
+// GetAllActiveProviders is a free data retrieval call binding the contract method 0x2f67c065.
+//
+// Solidity: function getAllActiveProviders(uint256 offset, uint256 limit) view returns(uint256[] providerIds, bool hasMore)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetAllActiveProviders(offset *big.Int, limit *big.Int) (struct {
+	ProviderIds []*big.Int
+	HasMore     bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetAllActiveProviders(&_ServiceProviderRegistry.CallOpts, offset, limit)
+}
+
+// GetNextProviderId is a free data retrieval call binding the contract method 0xd1329d4e.
+//
+// Solidity: function getNextProviderId() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetNextProviderId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getNextProviderId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetNextProviderId is a free data retrieval call binding the contract method 0xd1329d4e.
+//
+// Solidity: function getNextProviderId() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetNextProviderId() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.GetNextProviderId(&_ServiceProviderRegistry.CallOpts)
+}
+
+// GetNextProviderId is a free data retrieval call binding the contract method 0xd1329d4e.
+//
+// Solidity: function getNextProviderId() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetNextProviderId() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.GetNextProviderId(&_ServiceProviderRegistry.CallOpts)
+}
+
+// GetPDPService is a free data retrieval call binding the contract method 0xc439fd57.
+//
+// Solidity: function getPDPService(uint256 providerId) view returns((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering, string[] capabilityKeys, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetPDPService(opts *bind.CallOpts, providerId *big.Int) (struct {
+	PdpOffering    ServiceProviderRegistryStoragePDPOffering
+	CapabilityKeys []string
+	IsActive       bool
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getPDPService", providerId)
+
+	outstruct := new(struct {
+		PdpOffering    ServiceProviderRegistryStoragePDPOffering
+		CapabilityKeys []string
+		IsActive       bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.PdpOffering = *abi.ConvertType(out[0], new(ServiceProviderRegistryStoragePDPOffering)).(*ServiceProviderRegistryStoragePDPOffering)
+	outstruct.CapabilityKeys = *abi.ConvertType(out[1], new([]string)).(*[]string)
+	outstruct.IsActive = *abi.ConvertType(out[2], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// GetPDPService is a free data retrieval call binding the contract method 0xc439fd57.
+//
+// Solidity: function getPDPService(uint256 providerId) view returns((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering, string[] capabilityKeys, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetPDPService(providerId *big.Int) (struct {
+	PdpOffering    ServiceProviderRegistryStoragePDPOffering
+	CapabilityKeys []string
+	IsActive       bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetPDPService(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// GetPDPService is a free data retrieval call binding the contract method 0xc439fd57.
+//
+// Solidity: function getPDPService(uint256 providerId) view returns((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering, string[] capabilityKeys, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetPDPService(providerId *big.Int) (struct {
+	PdpOffering    ServiceProviderRegistryStoragePDPOffering
+	CapabilityKeys []string
+	IsActive       bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetPDPService(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// GetProduct is a free data retrieval call binding the contract method 0xaca0988f.
+//
+// Solidity: function getProduct(uint256 providerId, uint8 productType) view returns(bytes productData, string[] capabilityKeys, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProduct(opts *bind.CallOpts, providerId *big.Int, productType uint8) (struct {
+	ProductData    []byte
+	CapabilityKeys []string
+	IsActive       bool
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProduct", providerId, productType)
+
+	outstruct := new(struct {
+		ProductData    []byte
+		CapabilityKeys []string
+		IsActive       bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ProductData = *abi.ConvertType(out[0], new([]byte)).(*[]byte)
+	outstruct.CapabilityKeys = *abi.ConvertType(out[1], new([]string)).(*[]string)
+	outstruct.IsActive = *abi.ConvertType(out[2], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// GetProduct is a free data retrieval call binding the contract method 0xaca0988f.
+//
+// Solidity: function getProduct(uint256 providerId, uint8 productType) view returns(bytes productData, string[] capabilityKeys, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProduct(providerId *big.Int, productType uint8) (struct {
+	ProductData    []byte
+	CapabilityKeys []string
+	IsActive       bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetProduct(&_ServiceProviderRegistry.CallOpts, providerId, productType)
+}
+
+// GetProduct is a free data retrieval call binding the contract method 0xaca0988f.
+//
+// Solidity: function getProduct(uint256 providerId, uint8 productType) view returns(bytes productData, string[] capabilityKeys, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProduct(providerId *big.Int, productType uint8) (struct {
+	ProductData    []byte
+	CapabilityKeys []string
+	IsActive       bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetProduct(&_ServiceProviderRegistry.CallOpts, providerId, productType)
+}
+
+// GetProductCapabilities is a free data retrieval call binding the contract method 0xa6433240.
+//
+// Solidity: function getProductCapabilities(uint256 providerId, uint8 productType, string[] keys) view returns(bool[] exists, string[] values)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProductCapabilities(opts *bind.CallOpts, providerId *big.Int, productType uint8, keys []string) (struct {
+	Exists []bool
+	Values []string
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProductCapabilities", providerId, productType, keys)
+
+	outstruct := new(struct {
+		Exists []bool
+		Values []string
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Exists = *abi.ConvertType(out[0], new([]bool)).(*[]bool)
+	outstruct.Values = *abi.ConvertType(out[1], new([]string)).(*[]string)
+
+	return *outstruct, err
+
+}
+
+// GetProductCapabilities is a free data retrieval call binding the contract method 0xa6433240.
+//
+// Solidity: function getProductCapabilities(uint256 providerId, uint8 productType, string[] keys) view returns(bool[] exists, string[] values)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProductCapabilities(providerId *big.Int, productType uint8, keys []string) (struct {
+	Exists []bool
+	Values []string
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetProductCapabilities(&_ServiceProviderRegistry.CallOpts, providerId, productType, keys)
+}
+
+// GetProductCapabilities is a free data retrieval call binding the contract method 0xa6433240.
+//
+// Solidity: function getProductCapabilities(uint256 providerId, uint8 productType, string[] keys) view returns(bool[] exists, string[] values)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProductCapabilities(providerId *big.Int, productType uint8, keys []string) (struct {
+	Exists []bool
+	Values []string
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetProductCapabilities(&_ServiceProviderRegistry.CallOpts, providerId, productType, keys)
+}
+
+// GetProductCapability is a free data retrieval call binding the contract method 0x1e35bdde.
+//
+// Solidity: function getProductCapability(uint256 providerId, uint8 productType, string key) view returns(bool exists, string value)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProductCapability(opts *bind.CallOpts, providerId *big.Int, productType uint8, key string) (struct {
+	Exists bool
+	Value  string
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProductCapability", providerId, productType, key)
+
+	outstruct := new(struct {
+		Exists bool
+		Value  string
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Exists = *abi.ConvertType(out[0], new(bool)).(*bool)
+	outstruct.Value = *abi.ConvertType(out[1], new(string)).(*string)
+
+	return *outstruct, err
+
+}
+
+// GetProductCapability is a free data retrieval call binding the contract method 0x1e35bdde.
+//
+// Solidity: function getProductCapability(uint256 providerId, uint8 productType, string key) view returns(bool exists, string value)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProductCapability(providerId *big.Int, productType uint8, key string) (struct {
+	Exists bool
+	Value  string
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetProductCapability(&_ServiceProviderRegistry.CallOpts, providerId, productType, key)
+}
+
+// GetProductCapability is a free data retrieval call binding the contract method 0x1e35bdde.
+//
+// Solidity: function getProductCapability(uint256 providerId, uint8 productType, string key) view returns(bool exists, string value)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProductCapability(providerId *big.Int, productType uint8, key string) (struct {
+	Exists bool
+	Value  string
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetProductCapability(&_ServiceProviderRegistry.CallOpts, providerId, productType, key)
+}
+
+// GetProvider is a free data retrieval call binding the contract method 0x5c42d079.
+//
+// Solidity: function getProvider(uint256 providerId) view returns((uint256,(address,address,string,string,bool)) info)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProvider(opts *bind.CallOpts, providerId *big.Int) (ServiceProviderRegistryServiceProviderInfoView, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProvider", providerId)
+
+	if err != nil {
+		return *new(ServiceProviderRegistryServiceProviderInfoView), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(ServiceProviderRegistryServiceProviderInfoView)).(*ServiceProviderRegistryServiceProviderInfoView)
+
+	return out0, err
+
+}
+
+// GetProvider is a free data retrieval call binding the contract method 0x5c42d079.
+//
+// Solidity: function getProvider(uint256 providerId) view returns((uint256,(address,address,string,string,bool)) info)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProvider(providerId *big.Int) (ServiceProviderRegistryServiceProviderInfoView, error) {
+	return _ServiceProviderRegistry.Contract.GetProvider(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// GetProvider is a free data retrieval call binding the contract method 0x5c42d079.
+//
+// Solidity: function getProvider(uint256 providerId) view returns((uint256,(address,address,string,string,bool)) info)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProvider(providerId *big.Int) (ServiceProviderRegistryServiceProviderInfoView, error) {
+	return _ServiceProviderRegistry.Contract.GetProvider(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// GetProviderByAddress is a free data retrieval call binding the contract method 0x2335bde0.
+//
+// Solidity: function getProviderByAddress(address providerAddress) view returns((uint256,(address,address,string,string,bool)) info)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProviderByAddress(opts *bind.CallOpts, providerAddress common.Address) (ServiceProviderRegistryServiceProviderInfoView, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProviderByAddress", providerAddress)
+
+	if err != nil {
+		return *new(ServiceProviderRegistryServiceProviderInfoView), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(ServiceProviderRegistryServiceProviderInfoView)).(*ServiceProviderRegistryServiceProviderInfoView)
+
+	return out0, err
+
+}
+
+// GetProviderByAddress is a free data retrieval call binding the contract method 0x2335bde0.
+//
+// Solidity: function getProviderByAddress(address providerAddress) view returns((uint256,(address,address,string,string,bool)) info)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProviderByAddress(providerAddress common.Address) (ServiceProviderRegistryServiceProviderInfoView, error) {
+	return _ServiceProviderRegistry.Contract.GetProviderByAddress(&_ServiceProviderRegistry.CallOpts, providerAddress)
+}
+
+// GetProviderByAddress is a free data retrieval call binding the contract method 0x2335bde0.
+//
+// Solidity: function getProviderByAddress(address providerAddress) view returns((uint256,(address,address,string,string,bool)) info)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProviderByAddress(providerAddress common.Address) (ServiceProviderRegistryServiceProviderInfoView, error) {
+	return _ServiceProviderRegistry.Contract.GetProviderByAddress(&_ServiceProviderRegistry.CallOpts, providerAddress)
+}
+
+// GetProviderCount is a free data retrieval call binding the contract method 0x46ce4175.
+//
+// Solidity: function getProviderCount() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProviderCount(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProviderCount")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetProviderCount is a free data retrieval call binding the contract method 0x46ce4175.
+//
+// Solidity: function getProviderCount() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProviderCount() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.GetProviderCount(&_ServiceProviderRegistry.CallOpts)
+}
+
+// GetProviderCount is a free data retrieval call binding the contract method 0x46ce4175.
+//
+// Solidity: function getProviderCount() view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProviderCount() (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.GetProviderCount(&_ServiceProviderRegistry.CallOpts)
+}
+
+// GetProviderIdByAddress is a free data retrieval call binding the contract method 0x93ecb91e.
+//
+// Solidity: function getProviderIdByAddress(address providerAddress) view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProviderIdByAddress(opts *bind.CallOpts, providerAddress common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProviderIdByAddress", providerAddress)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetProviderIdByAddress is a free data retrieval call binding the contract method 0x93ecb91e.
+//
+// Solidity: function getProviderIdByAddress(address providerAddress) view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProviderIdByAddress(providerAddress common.Address) (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.GetProviderIdByAddress(&_ServiceProviderRegistry.CallOpts, providerAddress)
+}
+
+// GetProviderIdByAddress is a free data retrieval call binding the contract method 0x93ecb91e.
+//
+// Solidity: function getProviderIdByAddress(address providerAddress) view returns(uint256)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProviderIdByAddress(providerAddress common.Address) (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.GetProviderIdByAddress(&_ServiceProviderRegistry.CallOpts, providerAddress)
+}
+
+// GetProviderPayee is a free data retrieval call binding the contract method 0x60f4d53a.
+//
+// Solidity: function getProviderPayee(uint256 providerId) view returns(address payee)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProviderPayee(opts *bind.CallOpts, providerId *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProviderPayee", providerId)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetProviderPayee is a free data retrieval call binding the contract method 0x60f4d53a.
+//
+// Solidity: function getProviderPayee(uint256 providerId) view returns(address payee)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProviderPayee(providerId *big.Int) (common.Address, error) {
+	return _ServiceProviderRegistry.Contract.GetProviderPayee(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// GetProviderPayee is a free data retrieval call binding the contract method 0x60f4d53a.
+//
+// Solidity: function getProviderPayee(uint256 providerId) view returns(address payee)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProviderPayee(providerId *big.Int) (common.Address, error) {
+	return _ServiceProviderRegistry.Contract.GetProviderPayee(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// GetProvidersByIds is a free data retrieval call binding the contract method 0x5bfe9146.
+//
+// Solidity: function getProvidersByIds(uint256[] providerIds) view returns((uint256,(address,address,string,string,bool))[] providerInfos, bool[] validIds)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProvidersByIds(opts *bind.CallOpts, providerIds []*big.Int) (struct {
+	ProviderInfos []ServiceProviderRegistryServiceProviderInfoView
+	ValidIds      []bool
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProvidersByIds", providerIds)
+
+	outstruct := new(struct {
+		ProviderInfos []ServiceProviderRegistryServiceProviderInfoView
+		ValidIds      []bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ProviderInfos = *abi.ConvertType(out[0], new([]ServiceProviderRegistryServiceProviderInfoView)).(*[]ServiceProviderRegistryServiceProviderInfoView)
+	outstruct.ValidIds = *abi.ConvertType(out[1], new([]bool)).(*[]bool)
+
+	return *outstruct, err
+
+}
+
+// GetProvidersByIds is a free data retrieval call binding the contract method 0x5bfe9146.
+//
+// Solidity: function getProvidersByIds(uint256[] providerIds) view returns((uint256,(address,address,string,string,bool))[] providerInfos, bool[] validIds)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProvidersByIds(providerIds []*big.Int) (struct {
+	ProviderInfos []ServiceProviderRegistryServiceProviderInfoView
+	ValidIds      []bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetProvidersByIds(&_ServiceProviderRegistry.CallOpts, providerIds)
+}
+
+// GetProvidersByIds is a free data retrieval call binding the contract method 0x5bfe9146.
+//
+// Solidity: function getProvidersByIds(uint256[] providerIds) view returns((uint256,(address,address,string,string,bool))[] providerInfos, bool[] validIds)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProvidersByIds(providerIds []*big.Int) (struct {
+	ProviderInfos []ServiceProviderRegistryServiceProviderInfoView
+	ValidIds      []bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.GetProvidersByIds(&_ServiceProviderRegistry.CallOpts, providerIds)
+}
+
+// GetProvidersByProductType is a free data retrieval call binding the contract method 0xfc260f7b.
+//
+// Solidity: function getProvidersByProductType(uint8 productType, uint256 offset, uint256 limit) view returns(((uint256,(address,address,string,string,bool),(uint8,bytes,string[],bool))[],bool) result)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) GetProvidersByProductType(opts *bind.CallOpts, productType uint8, offset *big.Int, limit *big.Int) (ServiceProviderRegistryStoragePaginatedProviders, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "getProvidersByProductType", productType, offset, limit)
+
+	if err != nil {
+		return *new(ServiceProviderRegistryStoragePaginatedProviders), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(ServiceProviderRegistryStoragePaginatedProviders)).(*ServiceProviderRegistryStoragePaginatedProviders)
+
+	return out0, err
+
+}
+
+// GetProvidersByProductType is a free data retrieval call binding the contract method 0xfc260f7b.
+//
+// Solidity: function getProvidersByProductType(uint8 productType, uint256 offset, uint256 limit) view returns(((uint256,(address,address,string,string,bool),(uint8,bytes,string[],bool))[],bool) result)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) GetProvidersByProductType(productType uint8, offset *big.Int, limit *big.Int) (ServiceProviderRegistryStoragePaginatedProviders, error) {
+	return _ServiceProviderRegistry.Contract.GetProvidersByProductType(&_ServiceProviderRegistry.CallOpts, productType, offset, limit)
+}
+
+// GetProvidersByProductType is a free data retrieval call binding the contract method 0xfc260f7b.
+//
+// Solidity: function getProvidersByProductType(uint8 productType, uint256 offset, uint256 limit) view returns(((uint256,(address,address,string,string,bool),(uint8,bytes,string[],bool))[],bool) result)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) GetProvidersByProductType(productType uint8, offset *big.Int, limit *big.Int) (ServiceProviderRegistryStoragePaginatedProviders, error) {
+	return _ServiceProviderRegistry.Contract.GetProvidersByProductType(&_ServiceProviderRegistry.CallOpts, productType, offset, limit)
+}
+
+// IsProviderActive is a free data retrieval call binding the contract method 0x83df54a5.
+//
+// Solidity: function isProviderActive(uint256 providerId) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) IsProviderActive(opts *bind.CallOpts, providerId *big.Int) (bool, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "isProviderActive", providerId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsProviderActive is a free data retrieval call binding the contract method 0x83df54a5.
+//
+// Solidity: function isProviderActive(uint256 providerId) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) IsProviderActive(providerId *big.Int) (bool, error) {
+	return _ServiceProviderRegistry.Contract.IsProviderActive(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// IsProviderActive is a free data retrieval call binding the contract method 0x83df54a5.
+//
+// Solidity: function isProviderActive(uint256 providerId) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) IsProviderActive(providerId *big.Int) (bool, error) {
+	return _ServiceProviderRegistry.Contract.IsProviderActive(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// IsRegisteredProvider is a free data retrieval call binding the contract method 0x51ca236f.
+//
+// Solidity: function isRegisteredProvider(address provider) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) IsRegisteredProvider(opts *bind.CallOpts, provider common.Address) (bool, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "isRegisteredProvider", provider)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsRegisteredProvider is a free data retrieval call binding the contract method 0x51ca236f.
+//
+// Solidity: function isRegisteredProvider(address provider) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) IsRegisteredProvider(provider common.Address) (bool, error) {
+	return _ServiceProviderRegistry.Contract.IsRegisteredProvider(&_ServiceProviderRegistry.CallOpts, provider)
+}
+
+// IsRegisteredProvider is a free data retrieval call binding the contract method 0x51ca236f.
+//
+// Solidity: function isRegisteredProvider(address provider) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) IsRegisteredProvider(provider common.Address) (bool, error) {
+	return _ServiceProviderRegistry.Contract.IsRegisteredProvider(&_ServiceProviderRegistry.CallOpts, provider)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) Owner() (common.Address, error) {
+	return _ServiceProviderRegistry.Contract.Owner(&_ServiceProviderRegistry.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) Owner() (common.Address, error) {
+	return _ServiceProviderRegistry.Contract.Owner(&_ServiceProviderRegistry.CallOpts)
+}
+
+// ProductCapabilities is a free data retrieval call binding the contract method 0x4368bafb.
+//
+// Solidity: function productCapabilities(uint256 providerId, uint8 productType, string key) view returns(string value)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) ProductCapabilities(opts *bind.CallOpts, providerId *big.Int, productType uint8, key string) (string, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "productCapabilities", providerId, productType, key)
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// ProductCapabilities is a free data retrieval call binding the contract method 0x4368bafb.
+//
+// Solidity: function productCapabilities(uint256 providerId, uint8 productType, string key) view returns(string value)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) ProductCapabilities(providerId *big.Int, productType uint8, key string) (string, error) {
+	return _ServiceProviderRegistry.Contract.ProductCapabilities(&_ServiceProviderRegistry.CallOpts, providerId, productType, key)
+}
+
+// ProductCapabilities is a free data retrieval call binding the contract method 0x4368bafb.
+//
+// Solidity: function productCapabilities(uint256 providerId, uint8 productType, string key) view returns(string value)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) ProductCapabilities(providerId *big.Int, productType uint8, key string) (string, error) {
+	return _ServiceProviderRegistry.Contract.ProductCapabilities(&_ServiceProviderRegistry.CallOpts, providerId, productType, key)
+}
+
+// ProductTypeProviderCount is a free data retrieval call binding the contract method 0xe459382f.
+//
+// Solidity: function productTypeProviderCount(uint8 productType) view returns(uint256 count)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) ProductTypeProviderCount(opts *bind.CallOpts, productType uint8) (*big.Int, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "productTypeProviderCount", productType)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ProductTypeProviderCount is a free data retrieval call binding the contract method 0xe459382f.
+//
+// Solidity: function productTypeProviderCount(uint8 productType) view returns(uint256 count)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) ProductTypeProviderCount(productType uint8) (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.ProductTypeProviderCount(&_ServiceProviderRegistry.CallOpts, productType)
+}
+
+// ProductTypeProviderCount is a free data retrieval call binding the contract method 0xe459382f.
+//
+// Solidity: function productTypeProviderCount(uint8 productType) view returns(uint256 count)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) ProductTypeProviderCount(productType uint8) (*big.Int, error) {
+	return _ServiceProviderRegistry.Contract.ProductTypeProviderCount(&_ServiceProviderRegistry.CallOpts, productType)
+}
+
+// ProviderHasProduct is a free data retrieval call binding the contract method 0xcde24beb.
+//
+// Solidity: function providerHasProduct(uint256 providerId, uint8 productType) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) ProviderHasProduct(opts *bind.CallOpts, providerId *big.Int, productType uint8) (bool, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "providerHasProduct", providerId, productType)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ProviderHasProduct is a free data retrieval call binding the contract method 0xcde24beb.
+//
+// Solidity: function providerHasProduct(uint256 providerId, uint8 productType) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) ProviderHasProduct(providerId *big.Int, productType uint8) (bool, error) {
+	return _ServiceProviderRegistry.Contract.ProviderHasProduct(&_ServiceProviderRegistry.CallOpts, providerId, productType)
+}
+
+// ProviderHasProduct is a free data retrieval call binding the contract method 0xcde24beb.
+//
+// Solidity: function providerHasProduct(uint256 providerId, uint8 productType) view returns(bool)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) ProviderHasProduct(providerId *big.Int, productType uint8) (bool, error) {
+	return _ServiceProviderRegistry.Contract.ProviderHasProduct(&_ServiceProviderRegistry.CallOpts, providerId, productType)
+}
+
+// ProviderProducts is a free data retrieval call binding the contract method 0x6bf6d74f.
+//
+// Solidity: function providerProducts(uint256 providerId, uint8 productType) view returns(uint8 productType, bytes productData, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) ProviderProducts(opts *bind.CallOpts, providerId *big.Int, productType uint8) (struct {
+	ProductType uint8
+	ProductData []byte
+	IsActive    bool
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "providerProducts", providerId, productType)
+
+	outstruct := new(struct {
+		ProductType uint8
+		ProductData []byte
+		IsActive    bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ProductType = *abi.ConvertType(out[0], new(uint8)).(*uint8)
+	outstruct.ProductData = *abi.ConvertType(out[1], new([]byte)).(*[]byte)
+	outstruct.IsActive = *abi.ConvertType(out[2], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// ProviderProducts is a free data retrieval call binding the contract method 0x6bf6d74f.
+//
+// Solidity: function providerProducts(uint256 providerId, uint8 productType) view returns(uint8 productType, bytes productData, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) ProviderProducts(providerId *big.Int, productType uint8) (struct {
+	ProductType uint8
+	ProductData []byte
+	IsActive    bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.ProviderProducts(&_ServiceProviderRegistry.CallOpts, providerId, productType)
+}
+
+// ProviderProducts is a free data retrieval call binding the contract method 0x6bf6d74f.
+//
+// Solidity: function providerProducts(uint256 providerId, uint8 productType) view returns(uint8 productType, bytes productData, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) ProviderProducts(providerId *big.Int, productType uint8) (struct {
+	ProductType uint8
+	ProductData []byte
+	IsActive    bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.ProviderProducts(&_ServiceProviderRegistry.CallOpts, providerId, productType)
+}
+
+// Providers is a free data retrieval call binding the contract method 0x50f3fc81.
+//
+// Solidity: function providers(uint256 providerId) view returns(address serviceProvider, address payee, string name, string description, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) Providers(opts *bind.CallOpts, providerId *big.Int) (struct {
+	ServiceProvider common.Address
+	Payee           common.Address
+	Name            string
+	Description     string
+	IsActive        bool
+}, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "providers", providerId)
+
+	outstruct := new(struct {
+		ServiceProvider common.Address
+		Payee           common.Address
+		Name            string
+		Description     string
+		IsActive        bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ServiceProvider = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.Payee = *abi.ConvertType(out[1], new(common.Address)).(*common.Address)
+	outstruct.Name = *abi.ConvertType(out[2], new(string)).(*string)
+	outstruct.Description = *abi.ConvertType(out[3], new(string)).(*string)
+	outstruct.IsActive = *abi.ConvertType(out[4], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// Providers is a free data retrieval call binding the contract method 0x50f3fc81.
+//
+// Solidity: function providers(uint256 providerId) view returns(address serviceProvider, address payee, string name, string description, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) Providers(providerId *big.Int) (struct {
+	ServiceProvider common.Address
+	Payee           common.Address
+	Name            string
+	Description     string
+	IsActive        bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.Providers(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// Providers is a free data retrieval call binding the contract method 0x50f3fc81.
+//
+// Solidity: function providers(uint256 providerId) view returns(address serviceProvider, address payee, string name, string description, bool isActive)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) Providers(providerId *big.Int) (struct {
+	ServiceProvider common.Address
+	Payee           common.Address
+	Name            string
+	Description     string
+	IsActive        bool
+}, error) {
+	return _ServiceProviderRegistry.Contract.Providers(&_ServiceProviderRegistry.CallOpts, providerId)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _ServiceProviderRegistry.contract.Call(opts, &out, "proxiableUUID")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) ProxiableUUID() ([32]byte, error) {
+	return _ServiceProviderRegistry.Contract.ProxiableUUID(&_ServiceProviderRegistry.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_ServiceProviderRegistry *ServiceProviderRegistryCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _ServiceProviderRegistry.Contract.ProxiableUUID(&_ServiceProviderRegistry.CallOpts)
+}
+
+// AddProduct is a paid mutator transaction binding the contract method 0x02ff8437.
+//
+// Solidity: function addProduct(uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) AddProduct(opts *bind.TransactOpts, productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "addProduct", productType, productData, capabilityKeys, capabilityValues)
+}
+
+// AddProduct is a paid mutator transaction binding the contract method 0x02ff8437.
+//
+// Solidity: function addProduct(uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) AddProduct(productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.AddProduct(&_ServiceProviderRegistry.TransactOpts, productType, productData, capabilityKeys, capabilityValues)
+}
+
+// AddProduct is a paid mutator transaction binding the contract method 0x02ff8437.
+//
+// Solidity: function addProduct(uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) AddProduct(productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.AddProduct(&_ServiceProviderRegistry.TransactOpts, productType, productData, capabilityKeys, capabilityValues)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8129fc1c.
+//
+// Solidity: function initialize() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) Initialize(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "initialize")
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8129fc1c.
+//
+// Solidity: function initialize() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) Initialize() (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.Initialize(&_ServiceProviderRegistry.TransactOpts)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x8129fc1c.
+//
+// Solidity: function initialize() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) Initialize() (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.Initialize(&_ServiceProviderRegistry.TransactOpts)
+}
+
+// Migrate is a paid mutator transaction binding the contract method 0xc9c5b5b4.
+//
+// Solidity: function migrate(string newVersion) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) Migrate(opts *bind.TransactOpts, newVersion string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "migrate", newVersion)
+}
+
+// Migrate is a paid mutator transaction binding the contract method 0xc9c5b5b4.
+//
+// Solidity: function migrate(string newVersion) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) Migrate(newVersion string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.Migrate(&_ServiceProviderRegistry.TransactOpts, newVersion)
+}
+
+// Migrate is a paid mutator transaction binding the contract method 0xc9c5b5b4.
+//
+// Solidity: function migrate(string newVersion) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) Migrate(newVersion string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.Migrate(&_ServiceProviderRegistry.TransactOpts, newVersion)
+}
+
+// RegisterProvider is a paid mutator transaction binding the contract method 0xb47be8ab.
+//
+// Solidity: function registerProvider(address payee, string name, string description, uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) payable returns(uint256 providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) RegisterProvider(opts *bind.TransactOpts, payee common.Address, name string, description string, productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "registerProvider", payee, name, description, productType, productData, capabilityKeys, capabilityValues)
+}
+
+// RegisterProvider is a paid mutator transaction binding the contract method 0xb47be8ab.
+//
+// Solidity: function registerProvider(address payee, string name, string description, uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) payable returns(uint256 providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) RegisterProvider(payee common.Address, name string, description string, productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.RegisterProvider(&_ServiceProviderRegistry.TransactOpts, payee, name, description, productType, productData, capabilityKeys, capabilityValues)
+}
+
+// RegisterProvider is a paid mutator transaction binding the contract method 0xb47be8ab.
+//
+// Solidity: function registerProvider(address payee, string name, string description, uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) payable returns(uint256 providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) RegisterProvider(payee common.Address, name string, description string, productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.RegisterProvider(&_ServiceProviderRegistry.TransactOpts, payee, name, description, productType, productData, capabilityKeys, capabilityValues)
+}
+
+// RemoveProduct is a paid mutator transaction binding the contract method 0xa9d239b6.
+//
+// Solidity: function removeProduct(uint8 productType) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) RemoveProduct(opts *bind.TransactOpts, productType uint8) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "removeProduct", productType)
+}
+
+// RemoveProduct is a paid mutator transaction binding the contract method 0xa9d239b6.
+//
+// Solidity: function removeProduct(uint8 productType) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) RemoveProduct(productType uint8) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.RemoveProduct(&_ServiceProviderRegistry.TransactOpts, productType)
+}
+
+// RemoveProduct is a paid mutator transaction binding the contract method 0xa9d239b6.
+//
+// Solidity: function removeProduct(uint8 productType) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) RemoveProduct(productType uint8) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.RemoveProduct(&_ServiceProviderRegistry.TransactOpts, productType)
+}
+
+// RemoveProvider is a paid mutator transaction binding the contract method 0xb6363b99.
+//
+// Solidity: function removeProvider() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) RemoveProvider(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "removeProvider")
+}
+
+// RemoveProvider is a paid mutator transaction binding the contract method 0xb6363b99.
+//
+// Solidity: function removeProvider() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) RemoveProvider() (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.RemoveProvider(&_ServiceProviderRegistry.TransactOpts)
+}
+
+// RemoveProvider is a paid mutator transaction binding the contract method 0xb6363b99.
+//
+// Solidity: function removeProvider() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) RemoveProvider() (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.RemoveProvider(&_ServiceProviderRegistry.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) RenounceOwnership() (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.RenounceOwnership(&_ServiceProviderRegistry.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.RenounceOwnership(&_ServiceProviderRegistry.TransactOpts)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.TransferOwnership(&_ServiceProviderRegistry.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.TransferOwnership(&_ServiceProviderRegistry.TransactOpts, newOwner)
+}
+
+// UpdatePDPServiceWithCapabilities is a paid mutator transaction binding the contract method 0x0b5c0125.
+//
+// Solidity: function updatePDPServiceWithCapabilities((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) UpdatePDPServiceWithCapabilities(opts *bind.TransactOpts, pdpOffering ServiceProviderRegistryStoragePDPOffering, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "updatePDPServiceWithCapabilities", pdpOffering, capabilityKeys, capabilityValues)
+}
+
+// UpdatePDPServiceWithCapabilities is a paid mutator transaction binding the contract method 0x0b5c0125.
+//
+// Solidity: function updatePDPServiceWithCapabilities((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) UpdatePDPServiceWithCapabilities(pdpOffering ServiceProviderRegistryStoragePDPOffering, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.UpdatePDPServiceWithCapabilities(&_ServiceProviderRegistry.TransactOpts, pdpOffering, capabilityKeys, capabilityValues)
+}
+
+// UpdatePDPServiceWithCapabilities is a paid mutator transaction binding the contract method 0x0b5c0125.
+//
+// Solidity: function updatePDPServiceWithCapabilities((string,uint256,uint256,bool,bool,uint256,uint256,string,address) pdpOffering, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) UpdatePDPServiceWithCapabilities(pdpOffering ServiceProviderRegistryStoragePDPOffering, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.UpdatePDPServiceWithCapabilities(&_ServiceProviderRegistry.TransactOpts, pdpOffering, capabilityKeys, capabilityValues)
+}
+
+// UpdateProduct is a paid mutator transaction binding the contract method 0x8c9a7b56.
+//
+// Solidity: function updateProduct(uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) UpdateProduct(opts *bind.TransactOpts, productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "updateProduct", productType, productData, capabilityKeys, capabilityValues)
+}
+
+// UpdateProduct is a paid mutator transaction binding the contract method 0x8c9a7b56.
+//
+// Solidity: function updateProduct(uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) UpdateProduct(productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.UpdateProduct(&_ServiceProviderRegistry.TransactOpts, productType, productData, capabilityKeys, capabilityValues)
+}
+
+// UpdateProduct is a paid mutator transaction binding the contract method 0x8c9a7b56.
+//
+// Solidity: function updateProduct(uint8 productType, bytes productData, string[] capabilityKeys, string[] capabilityValues) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) UpdateProduct(productType uint8, productData []byte, capabilityKeys []string, capabilityValues []string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.UpdateProduct(&_ServiceProviderRegistry.TransactOpts, productType, productData, capabilityKeys, capabilityValues)
+}
+
+// UpdateProviderInfo is a paid mutator transaction binding the contract method 0xd1c21b5b.
+//
+// Solidity: function updateProviderInfo(string name, string description) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) UpdateProviderInfo(opts *bind.TransactOpts, name string, description string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "updateProviderInfo", name, description)
+}
+
+// UpdateProviderInfo is a paid mutator transaction binding the contract method 0xd1c21b5b.
+//
+// Solidity: function updateProviderInfo(string name, string description) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) UpdateProviderInfo(name string, description string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.UpdateProviderInfo(&_ServiceProviderRegistry.TransactOpts, name, description)
+}
+
+// UpdateProviderInfo is a paid mutator transaction binding the contract method 0xd1c21b5b.
+//
+// Solidity: function updateProviderInfo(string name, string description) returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) UpdateProviderInfo(name string, description string) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.UpdateProviderInfo(&_ServiceProviderRegistry.TransactOpts, name, description)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistrySession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.UpgradeToAndCall(&_ServiceProviderRegistry.TransactOpts, newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_ServiceProviderRegistry *ServiceProviderRegistryTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _ServiceProviderRegistry.Contract.UpgradeToAndCall(&_ServiceProviderRegistry.TransactOpts, newImplementation, data)
+}
+
+// ServiceProviderRegistryContractUpgradedIterator is returned from FilterContractUpgraded and is used to iterate over the raw logs and unpacked data for ContractUpgraded events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryContractUpgradedIterator struct {
+	Event *ServiceProviderRegistryContractUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryContractUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryContractUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryContractUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryContractUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryContractUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryContractUpgraded represents a ContractUpgraded event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryContractUpgraded struct {
+	Version        string
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterContractUpgraded is a free log retrieval operation binding the contract event 0x2b51ff7c4cc8e6fe1c72e9d9685b7d2a88a5d82ad3a644afbdceb0272c89c1c3.
+//
+// Solidity: event ContractUpgraded(string version, address implementation)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterContractUpgraded(opts *bind.FilterOpts) (*ServiceProviderRegistryContractUpgradedIterator, error) {
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "ContractUpgraded")
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryContractUpgradedIterator{contract: _ServiceProviderRegistry.contract, event: "ContractUpgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchContractUpgraded is a free log subscription operation binding the contract event 0x2b51ff7c4cc8e6fe1c72e9d9685b7d2a88a5d82ad3a644afbdceb0272c89c1c3.
+//
+// Solidity: event ContractUpgraded(string version, address implementation)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchContractUpgraded(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryContractUpgraded) (event.Subscription, error) {
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "ContractUpgraded")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryContractUpgraded)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ContractUpgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseContractUpgraded is a log parse operation binding the contract event 0x2b51ff7c4cc8e6fe1c72e9d9685b7d2a88a5d82ad3a644afbdceb0272c89c1c3.
+//
+// Solidity: event ContractUpgraded(string version, address implementation)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseContractUpgraded(log types.Log) (*ServiceProviderRegistryContractUpgraded, error) {
+	event := new(ServiceProviderRegistryContractUpgraded)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ContractUpgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryEIP712DomainChangedIterator is returned from FilterEIP712DomainChanged and is used to iterate over the raw logs and unpacked data for EIP712DomainChanged events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryEIP712DomainChangedIterator struct {
+	Event *ServiceProviderRegistryEIP712DomainChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryEIP712DomainChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryEIP712DomainChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryEIP712DomainChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryEIP712DomainChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryEIP712DomainChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryEIP712DomainChanged represents a EIP712DomainChanged event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryEIP712DomainChanged struct {
+	Raw types.Log // Blockchain specific contextual infos
+}
+
+// FilterEIP712DomainChanged is a free log retrieval operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterEIP712DomainChanged(opts *bind.FilterOpts) (*ServiceProviderRegistryEIP712DomainChangedIterator, error) {
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "EIP712DomainChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryEIP712DomainChangedIterator{contract: _ServiceProviderRegistry.contract, event: "EIP712DomainChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchEIP712DomainChanged is a free log subscription operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchEIP712DomainChanged(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryEIP712DomainChanged) (event.Subscription, error) {
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "EIP712DomainChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryEIP712DomainChanged)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "EIP712DomainChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEIP712DomainChanged is a log parse operation binding the contract event 0x0a6387c9ea3628b88a633bb4f3b151770f70085117a15f9bf3787cda53f13d31.
+//
+// Solidity: event EIP712DomainChanged()
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseEIP712DomainChanged(log types.Log) (*ServiceProviderRegistryEIP712DomainChanged, error) {
+	event := new(ServiceProviderRegistryEIP712DomainChanged)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "EIP712DomainChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryInitializedIterator struct {
+	Event *ServiceProviderRegistryInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryInitialized represents a Initialized event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterInitialized(opts *bind.FilterOpts) (*ServiceProviderRegistryInitializedIterator, error) {
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryInitializedIterator{contract: _ServiceProviderRegistry.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryInitialized)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseInitialized(log types.Log) (*ServiceProviderRegistryInitialized, error) {
+	event := new(ServiceProviderRegistryInitialized)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryOwnershipTransferredIterator struct {
+	Event *ServiceProviderRegistryOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryOwnershipTransferred represents a OwnershipTransferred event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ServiceProviderRegistryOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryOwnershipTransferredIterator{contract: _ServiceProviderRegistry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryOwnershipTransferred)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseOwnershipTransferred(log types.Log) (*ServiceProviderRegistryOwnershipTransferred, error) {
+	event := new(ServiceProviderRegistryOwnershipTransferred)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryProductAddedIterator is returned from FilterProductAdded and is used to iterate over the raw logs and unpacked data for ProductAdded events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProductAddedIterator struct {
+	Event *ServiceProviderRegistryProductAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryProductAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryProductAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryProductAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryProductAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryProductAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryProductAdded represents a ProductAdded event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProductAdded struct {
+	ProviderId       *big.Int
+	ProductType      uint8
+	ServiceUrl       string
+	ServiceProvider  common.Address
+	CapabilityKeys   []string
+	CapabilityValues []string
+	Raw              types.Log // Blockchain specific contextual infos
+}
+
+// FilterProductAdded is a free log retrieval operation binding the contract event 0x93c484964e7897bebc18f4392da3a48d42bf4356601904bf354a6537376af717.
+//
+// Solidity: event ProductAdded(uint256 indexed providerId, uint8 indexed productType, string serviceUrl, address serviceProvider, string[] capabilityKeys, string[] capabilityValues)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterProductAdded(opts *bind.FilterOpts, providerId []*big.Int, productType []uint8) (*ServiceProviderRegistryProductAddedIterator, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+	var productTypeRule []interface{}
+	for _, productTypeItem := range productType {
+		productTypeRule = append(productTypeRule, productTypeItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "ProductAdded", providerIdRule, productTypeRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryProductAddedIterator{contract: _ServiceProviderRegistry.contract, event: "ProductAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchProductAdded is a free log subscription operation binding the contract event 0x93c484964e7897bebc18f4392da3a48d42bf4356601904bf354a6537376af717.
+//
+// Solidity: event ProductAdded(uint256 indexed providerId, uint8 indexed productType, string serviceUrl, address serviceProvider, string[] capabilityKeys, string[] capabilityValues)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchProductAdded(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryProductAdded, providerId []*big.Int, productType []uint8) (event.Subscription, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+	var productTypeRule []interface{}
+	for _, productTypeItem := range productType {
+		productTypeRule = append(productTypeRule, productTypeItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "ProductAdded", providerIdRule, productTypeRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryProductAdded)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProductAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProductAdded is a log parse operation binding the contract event 0x93c484964e7897bebc18f4392da3a48d42bf4356601904bf354a6537376af717.
+//
+// Solidity: event ProductAdded(uint256 indexed providerId, uint8 indexed productType, string serviceUrl, address serviceProvider, string[] capabilityKeys, string[] capabilityValues)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseProductAdded(log types.Log) (*ServiceProviderRegistryProductAdded, error) {
+	event := new(ServiceProviderRegistryProductAdded)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProductAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryProductRemovedIterator is returned from FilterProductRemoved and is used to iterate over the raw logs and unpacked data for ProductRemoved events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProductRemovedIterator struct {
+	Event *ServiceProviderRegistryProductRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryProductRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryProductRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryProductRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryProductRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryProductRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryProductRemoved represents a ProductRemoved event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProductRemoved struct {
+	ProviderId  *big.Int
+	ProductType uint8
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterProductRemoved is a free log retrieval operation binding the contract event 0x4c363c6cd3d80189ef501b26de41894b3ed5e7b4a85b096be6cbcaa8a13e5e4d.
+//
+// Solidity: event ProductRemoved(uint256 indexed providerId, uint8 indexed productType)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterProductRemoved(opts *bind.FilterOpts, providerId []*big.Int, productType []uint8) (*ServiceProviderRegistryProductRemovedIterator, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+	var productTypeRule []interface{}
+	for _, productTypeItem := range productType {
+		productTypeRule = append(productTypeRule, productTypeItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "ProductRemoved", providerIdRule, productTypeRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryProductRemovedIterator{contract: _ServiceProviderRegistry.contract, event: "ProductRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchProductRemoved is a free log subscription operation binding the contract event 0x4c363c6cd3d80189ef501b26de41894b3ed5e7b4a85b096be6cbcaa8a13e5e4d.
+//
+// Solidity: event ProductRemoved(uint256 indexed providerId, uint8 indexed productType)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchProductRemoved(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryProductRemoved, providerId []*big.Int, productType []uint8) (event.Subscription, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+	var productTypeRule []interface{}
+	for _, productTypeItem := range productType {
+		productTypeRule = append(productTypeRule, productTypeItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "ProductRemoved", providerIdRule, productTypeRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryProductRemoved)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProductRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProductRemoved is a log parse operation binding the contract event 0x4c363c6cd3d80189ef501b26de41894b3ed5e7b4a85b096be6cbcaa8a13e5e4d.
+//
+// Solidity: event ProductRemoved(uint256 indexed providerId, uint8 indexed productType)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseProductRemoved(log types.Log) (*ServiceProviderRegistryProductRemoved, error) {
+	event := new(ServiceProviderRegistryProductRemoved)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProductRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryProductUpdatedIterator is returned from FilterProductUpdated and is used to iterate over the raw logs and unpacked data for ProductUpdated events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProductUpdatedIterator struct {
+	Event *ServiceProviderRegistryProductUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryProductUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryProductUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryProductUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryProductUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryProductUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryProductUpdated represents a ProductUpdated event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProductUpdated struct {
+	ProviderId       *big.Int
+	ProductType      uint8
+	ServiceUrl       string
+	ServiceProvider  common.Address
+	CapabilityKeys   []string
+	CapabilityValues []string
+	Raw              types.Log // Blockchain specific contextual infos
+}
+
+// FilterProductUpdated is a free log retrieval operation binding the contract event 0xc340a6dcdd0e7d3f96b6b2d3729fe5f0a6114e5847ba52b9e0071bf156dbaed6.
+//
+// Solidity: event ProductUpdated(uint256 indexed providerId, uint8 indexed productType, string serviceUrl, address serviceProvider, string[] capabilityKeys, string[] capabilityValues)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterProductUpdated(opts *bind.FilterOpts, providerId []*big.Int, productType []uint8) (*ServiceProviderRegistryProductUpdatedIterator, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+	var productTypeRule []interface{}
+	for _, productTypeItem := range productType {
+		productTypeRule = append(productTypeRule, productTypeItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "ProductUpdated", providerIdRule, productTypeRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryProductUpdatedIterator{contract: _ServiceProviderRegistry.contract, event: "ProductUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchProductUpdated is a free log subscription operation binding the contract event 0xc340a6dcdd0e7d3f96b6b2d3729fe5f0a6114e5847ba52b9e0071bf156dbaed6.
+//
+// Solidity: event ProductUpdated(uint256 indexed providerId, uint8 indexed productType, string serviceUrl, address serviceProvider, string[] capabilityKeys, string[] capabilityValues)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchProductUpdated(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryProductUpdated, providerId []*big.Int, productType []uint8) (event.Subscription, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+	var productTypeRule []interface{}
+	for _, productTypeItem := range productType {
+		productTypeRule = append(productTypeRule, productTypeItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "ProductUpdated", providerIdRule, productTypeRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryProductUpdated)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProductUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProductUpdated is a log parse operation binding the contract event 0xc340a6dcdd0e7d3f96b6b2d3729fe5f0a6114e5847ba52b9e0071bf156dbaed6.
+//
+// Solidity: event ProductUpdated(uint256 indexed providerId, uint8 indexed productType, string serviceUrl, address serviceProvider, string[] capabilityKeys, string[] capabilityValues)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseProductUpdated(log types.Log) (*ServiceProviderRegistryProductUpdated, error) {
+	event := new(ServiceProviderRegistryProductUpdated)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProductUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryProviderInfoUpdatedIterator is returned from FilterProviderInfoUpdated and is used to iterate over the raw logs and unpacked data for ProviderInfoUpdated events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProviderInfoUpdatedIterator struct {
+	Event *ServiceProviderRegistryProviderInfoUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryProviderInfoUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryProviderInfoUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryProviderInfoUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryProviderInfoUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryProviderInfoUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryProviderInfoUpdated represents a ProviderInfoUpdated event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProviderInfoUpdated struct {
+	ProviderId *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderInfoUpdated is a free log retrieval operation binding the contract event 0xae10af73bdb200f240b1ea85ef806346fb24c82388af00414f4c5fcfeef68f76.
+//
+// Solidity: event ProviderInfoUpdated(uint256 indexed providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterProviderInfoUpdated(opts *bind.FilterOpts, providerId []*big.Int) (*ServiceProviderRegistryProviderInfoUpdatedIterator, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "ProviderInfoUpdated", providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryProviderInfoUpdatedIterator{contract: _ServiceProviderRegistry.contract, event: "ProviderInfoUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderInfoUpdated is a free log subscription operation binding the contract event 0xae10af73bdb200f240b1ea85ef806346fb24c82388af00414f4c5fcfeef68f76.
+//
+// Solidity: event ProviderInfoUpdated(uint256 indexed providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchProviderInfoUpdated(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryProviderInfoUpdated, providerId []*big.Int) (event.Subscription, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "ProviderInfoUpdated", providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryProviderInfoUpdated)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProviderInfoUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderInfoUpdated is a log parse operation binding the contract event 0xae10af73bdb200f240b1ea85ef806346fb24c82388af00414f4c5fcfeef68f76.
+//
+// Solidity: event ProviderInfoUpdated(uint256 indexed providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseProviderInfoUpdated(log types.Log) (*ServiceProviderRegistryProviderInfoUpdated, error) {
+	event := new(ServiceProviderRegistryProviderInfoUpdated)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProviderInfoUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryProviderRegisteredIterator is returned from FilterProviderRegistered and is used to iterate over the raw logs and unpacked data for ProviderRegistered events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProviderRegisteredIterator struct {
+	Event *ServiceProviderRegistryProviderRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryProviderRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryProviderRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryProviderRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryProviderRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryProviderRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryProviderRegistered represents a ProviderRegistered event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProviderRegistered struct {
+	ProviderId      *big.Int
+	ServiceProvider common.Address
+	Payee           common.Address
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderRegistered is a free log retrieval operation binding the contract event 0xaff7a33d237d3d600a92c556cda34cb73cf7cccc667e163c90b1d2d392b031a5.
+//
+// Solidity: event ProviderRegistered(uint256 indexed providerId, address indexed serviceProvider, address indexed payee)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterProviderRegistered(opts *bind.FilterOpts, providerId []*big.Int, serviceProvider []common.Address, payee []common.Address) (*ServiceProviderRegistryProviderRegisteredIterator, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+	var serviceProviderRule []interface{}
+	for _, serviceProviderItem := range serviceProvider {
+		serviceProviderRule = append(serviceProviderRule, serviceProviderItem)
+	}
+	var payeeRule []interface{}
+	for _, payeeItem := range payee {
+		payeeRule = append(payeeRule, payeeItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "ProviderRegistered", providerIdRule, serviceProviderRule, payeeRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryProviderRegisteredIterator{contract: _ServiceProviderRegistry.contract, event: "ProviderRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderRegistered is a free log subscription operation binding the contract event 0xaff7a33d237d3d600a92c556cda34cb73cf7cccc667e163c90b1d2d392b031a5.
+//
+// Solidity: event ProviderRegistered(uint256 indexed providerId, address indexed serviceProvider, address indexed payee)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchProviderRegistered(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryProviderRegistered, providerId []*big.Int, serviceProvider []common.Address, payee []common.Address) (event.Subscription, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+	var serviceProviderRule []interface{}
+	for _, serviceProviderItem := range serviceProvider {
+		serviceProviderRule = append(serviceProviderRule, serviceProviderItem)
+	}
+	var payeeRule []interface{}
+	for _, payeeItem := range payee {
+		payeeRule = append(payeeRule, payeeItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "ProviderRegistered", providerIdRule, serviceProviderRule, payeeRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryProviderRegistered)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProviderRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderRegistered is a log parse operation binding the contract event 0xaff7a33d237d3d600a92c556cda34cb73cf7cccc667e163c90b1d2d392b031a5.
+//
+// Solidity: event ProviderRegistered(uint256 indexed providerId, address indexed serviceProvider, address indexed payee)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseProviderRegistered(log types.Log) (*ServiceProviderRegistryProviderRegistered, error) {
+	event := new(ServiceProviderRegistryProviderRegistered)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProviderRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryProviderRemovedIterator is returned from FilterProviderRemoved and is used to iterate over the raw logs and unpacked data for ProviderRemoved events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProviderRemovedIterator struct {
+	Event *ServiceProviderRegistryProviderRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryProviderRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryProviderRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryProviderRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryProviderRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryProviderRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryProviderRemoved represents a ProviderRemoved event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryProviderRemoved struct {
+	ProviderId *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterProviderRemoved is a free log retrieval operation binding the contract event 0x452148878c72ebab44f2761cb8b0b79c50628a437350aee5f3aab66625addcc4.
+//
+// Solidity: event ProviderRemoved(uint256 indexed providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterProviderRemoved(opts *bind.FilterOpts, providerId []*big.Int) (*ServiceProviderRegistryProviderRemovedIterator, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "ProviderRemoved", providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryProviderRemovedIterator{contract: _ServiceProviderRegistry.contract, event: "ProviderRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchProviderRemoved is a free log subscription operation binding the contract event 0x452148878c72ebab44f2761cb8b0b79c50628a437350aee5f3aab66625addcc4.
+//
+// Solidity: event ProviderRemoved(uint256 indexed providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchProviderRemoved(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryProviderRemoved, providerId []*big.Int) (event.Subscription, error) {
+
+	var providerIdRule []interface{}
+	for _, providerIdItem := range providerId {
+		providerIdRule = append(providerIdRule, providerIdItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "ProviderRemoved", providerIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryProviderRemoved)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProviderRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseProviderRemoved is a log parse operation binding the contract event 0x452148878c72ebab44f2761cb8b0b79c50628a437350aee5f3aab66625addcc4.
+//
+// Solidity: event ProviderRemoved(uint256 indexed providerId)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseProviderRemoved(log types.Log) (*ServiceProviderRegistryProviderRemoved, error) {
+	event := new(ServiceProviderRegistryProviderRemoved)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "ProviderRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ServiceProviderRegistryUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryUpgradedIterator struct {
+	Event *ServiceProviderRegistryUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ServiceProviderRegistryUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ServiceProviderRegistryUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ServiceProviderRegistryUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ServiceProviderRegistryUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ServiceProviderRegistryUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ServiceProviderRegistryUpgraded represents a Upgraded event raised by the ServiceProviderRegistry contract.
+type ServiceProviderRegistryUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*ServiceProviderRegistryUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceProviderRegistryUpgradedIterator{contract: _ServiceProviderRegistry.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *ServiceProviderRegistryUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _ServiceProviderRegistry.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ServiceProviderRegistryUpgraded)
+				if err := _ServiceProviderRegistry.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_ServiceProviderRegistry *ServiceProviderRegistryFilterer) ParseUpgraded(log types.Log) (*ServiceProviderRegistryUpgraded, error) {
+	event := new(ServiceProviderRegistryUpgraded)
+	if err := _ServiceProviderRegistry.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/pkg/pdp/types/api.go
+++ b/pkg/pdp/types/api.go
@@ -115,6 +115,7 @@ type PieceUpload struct {
 type API interface {
 	ProofSetAPI
 	PieceAPI
+	ProviderAPI
 }
 
 type AllocatedPiece struct {
@@ -135,6 +136,37 @@ type CreateProofSetParams struct {
 	RecordKeeper common.Address
 	ExtraData    ExtraData
 }
+
+type RegisterProviderParams struct {
+	Name        string
+	Description string
+}
+
+type RegisterProviderResults struct {
+	// transaction hash of message sent by provider to register, when set all
+	// other fields are empty
+	TransactionHash common.Hash
+	// address of the provider
+	Address common.Address
+	// address the provider will receive payment on
+	Payee common.Address
+	// ID of provider
+	ID uint64
+	// True if the provider is registered (don't imply they have been approved
+	// the service contract.
+	IsActive bool
+	// Optional name chosen by provider
+	Name string
+	// Optional description chosen by provider
+	Description string
+}
+
+const (
+	ProductTypePDP uint8 = 0
+	// TODO we need to generate type for this from the contract ABI
+	// this is based on the contract code, right now there is only a single product type
+	// as an enum, so it's value is 0
+)
 
 type ProofSetAPI interface {
 	CreateProofSet(ctx context.Context, params CreateProofSetParams) (common.Hash, error)
@@ -174,4 +206,8 @@ type PieceAPI interface {
 	UploadPiece(ctx context.Context, upload PieceUpload) error
 	FindPiece(ctx context.Context, piece Piece) (cid.Cid, bool, error)
 	ReadPiece(ctx context.Context, piece cid.Cid, options ...ReadPieceOption) (*PieceReader, error)
+}
+
+type ProviderAPI interface {
+	RegisterProvider(ctx context.Context, params RegisterProviderParams) (RegisterProviderResults, error)
 }


### PR DESCRIPTION
# Summary

Adds support for registering PDP service providers with the ServiceProviderRegistry smart contract, this is a prerequist for interaction with the service contract.

**Please see the bottom of this PR description, I have open questions and provide more context on next steps**

# Changes

## Service Layer
  - pkg/pdp/service/provider_register.go: Implements RegisterProvider() method
    - Checks if provider is already registered using IsRegisteredProvider()
    - Returns existing provider info if already registered
    - Constructs and sends registration transaction with provider metadata (name, description, PDP offering)
    - Stores transaction hash in database for tracking

## HTTP API

  - Server (pkg/pdp/httpapi/server/register_provider.go):
    - POST /pdp/provider/register - Registers provider with optional name and description
    - Returns provider details including transaction hash, address, payee, ID, and status
  - Client (pkg/pdp/httpapi/client/client.go):
    - RegisterProvider() method for programmatic access
  - Types (pkg/pdp/httpapi/types.go):
    - RegisterProviderRequest - name and description fields
    - RegisterProviderResponse - comprehensive provider information

## CLI

  - cmd/cli/client/pdp/provider/: New provider command group
    - piri client pdp provider register --name <name> --description <desc>
    - Outputs JSON with provider registration results
    - Both flags are required

## Smart Contract Integration
  - Generate Bindings (pkg/pdp/smartcontracts/bindings/service_provider_registry.go): These are based on our fork of the contract in https://github.com/storacha/filecoin-services/blob/main/service_contracts/src/ServiceProviderRegistry.sol will try and have CI setup for this to make the abi generation less manual.

## Usage

**Register as a provider:**
```bash
  piri client pdp provider register \
    --name "My Provider" \
    --description "Reliable storage with 90 9's of uptime or whatever"
```
**Response**:
```json
  {
    "txHash": "0x...",
    "address": "0x...",
    "payee": "0x...",
    "id": 1,
    "isActive": true,
    "name": "My PDP Provider",
    "description": "Reliable storage with 90 9's of uptime or whatever"
  }
```

## Technical Notes
  - Registration requires 5 FIL fee (burned by contract)
    - We (cc @hannahhoward @alanshaw) may want to consider this fee: It serves as an economic spam prevention mechanism. The fee is burned by sending it to the `BURN_ACTOR` address, ofc this amount is configurable via contract modification, as is the location the fee is sent too.
  - Method is idempotent - calling multiple times returns existing registration
    - **caveat** here is that calling the method more than once in an epoch will result in wasted gas. We could put the work in now to prevent this, as my comment in code outlines, but I am being lazy for the time being, and overloading this method as both a registration method, and status method. 
  - Provider ID is assigned by the contract upon successful registration - its a counter that just goes up, similar to data set IDs

## Work to follow
Once a provider is registered, we as the owners of the service contract must approve the provider. Obv this isn't code we'll add to this repo, feedback welcome on where the "approval" mechanism should land. Note that "approvals" are sent to the warm storage contract address, not the registry. 

Getting into the details a bit, we can register a provider using the `cast` cli too (part of foundry) like this:
```bash
cast send $FILECOIN_WARM_STORAGE_SERVICE_ADDRESS \
    "addApprovedProvider(uint256)" \
    $PROVIDER_ID \
    --rpc-url $RPC_URL \
    --private-key $OWNER_PRIVATE_KEY
```
Where `RPC_URL` is a lotus node (e.g. Glif RPC) and `OWNER_PRIVATE_KEY` is the sk of the wallet we deployed the contract with, which I have shared out-of-band to this work. 