### PR TITLE
fix: incremental SHA hashing works for fsjournal resume

### DIFF
--- a/pkg/store/retrievaljournal/fsjournal.go
+++ b/pkg/store/retrievaljournal/fsjournal.go
@@ -108,10 +108,6 @@ func (j *fsJournal) newBatch(truncate bool) error {
 			if _, err := io.Copy(j.currHash, j.currBatch); err != nil {
 				return err
 			}
-			// Seek back to end for appending
-			if _, err := j.currBatch.Seek(0, io.SeekEnd); err != nil {
-				return err
-			}
 		}
 	}
 

--- a/pkg/store/retrievaljournal/fsjournal.go
+++ b/pkg/store/retrievaljournal/fsjournal.go
@@ -98,6 +98,21 @@ func (j *fsJournal) newBatch(truncate bool) error {
 		}
 
 		j.currSize = info.Size()
+
+		// If the file has existing content, hash it to ensure the final hash
+		// includes all data, not just what we append in this session
+		if j.currSize > 0 {
+			if _, err := j.currBatch.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+			if _, err := io.Copy(j.currHash, j.currBatch); err != nil {
+				return err
+			}
+			// Seek back to end for appending
+			if _, err := j.currBatch.Seek(0, io.SeekEnd); err != nil {
+				return err
+			}
+		}
 	}
 
 	if j.currSize == 0 {


### PR DESCRIPTION
small fix/follow-on to https://github.com/storacha/piri/pull/245
Ensures when a journal is resumed, the incremental sha is re-computed, see `TestResumeAfterRestart` for details.