### PR TITLE
fix: don't use V1Link

### DIFF
--- a/pkg/pdp/piecefinder/finder.go
+++ b/pkg/pdp/piecefinder/finder.go
@@ -100,5 +100,5 @@ func (a *CurioFinder) FindPiece(ctx context.Context, digest multihash.Multihash,
 }
 
 func (a *CurioFinder) URLForPiece(ctx context.Context, p piece.PieceLink) (url.URL, error) {
-	return *a.endpoint.JoinPath(p.V1Link().String()), nil
+	return *a.endpoint.JoinPath(p.Link().String()), nil
 }

--- a/pkg/pdp/piecefinder/finder_test.go
+++ b/pkg/pdp/piecefinder/finder_test.go
@@ -77,7 +77,7 @@ func TestFindPiece_RetryThenSuccess(t *testing.T) {
 
 	res, err := finder.FindPiece(ctx, expectedMh, expectedSize)
 	require.NoError(t, err)
-	require.Equal(t, expectedPiece.V1Link().String(), res.V1Link().String())
+	require.Equal(t, expectedPiece.Link().String(), res.Link().String())
 }
 
 func TestFindPiece_ExceedMaxRetries(t *testing.T) {
@@ -177,7 +177,7 @@ func TestURLForPiece(t *testing.T) {
 
 	ref, err := pa.URLForPiece(ctx, expectedPiece)
 	require.NoError(t, err)
-	require.Equal(t, expectedURL.JoinPath("piece", expectedPiece.V1Link().String()).String(), ref.String())
+	require.Equal(t, expectedURL.JoinPath("piece", expectedPiece.Link().String()).String(), ref.String())
 
 }
 

--- a/pkg/pdp/store/adapter/blobgetter.go
+++ b/pkg/pdp/store/adapter/blobgetter.go
@@ -52,7 +52,7 @@ func (bga *BlobGetterAdapter) Get(ctx context.Context, digest multihash.Multihas
 	if err != nil {
 		return nil, fmt.Errorf("finding piece link for %s: %w", digestutil.Format(digest), err)
 	}
-	res, err := bga.pieceReader.ReadPiece(ctx, pieceLink.V1Link().(cidlink.Link).Cid, types.WithRange(cfg.ByteRange.Start, cfg.ByteRange.End))
+	res, err := bga.pieceReader.ReadPiece(ctx, pieceLink.Link().(cidlink.Link).Cid, types.WithRange(cfg.ByteRange.Start, cfg.ByteRange.End))
 	if err != nil {
 		return nil, fmt.Errorf("reading piece: %w", err)
 	}

--- a/pkg/pdp/store/adapter/blobgetter_test.go
+++ b/pkg/pdp/store/adapter/blobgetter_test.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"testing"
 
-	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
 	"github.com/storacha/go-libstoracha/digestutil"
 	"github.com/storacha/go-libstoracha/piece/piece"
@@ -27,7 +27,7 @@ func TestBlobGetterAdapter(t *testing.T) {
 		digest := testutil.MultihashFromBytes(t, data)
 		digestStr := digestutil.Format(digest)
 		pieceLink := testutil.RandomPiece(t, int64(len(data)))
-		pieceLinkStr := pieceLink.V1Link().String()
+		pieceLinkStr := pieceLink.Link().String()
 
 		finder := mockPieceFinder{map[string]piece.PieceLink{digestStr: pieceLink}}
 		reader := mockPieceReader{map[string][]byte{pieceLinkStr: data}}
@@ -46,7 +46,7 @@ func TestBlobGetterAdapter(t *testing.T) {
 		digest := testutil.MultihashFromBytes(t, data)
 		digestStr := digestutil.Format(digest)
 		pieceLink := testutil.RandomPiece(t, int64(len(data)))
-		pieceLinkStr := pieceLink.V1Link().String()
+		pieceLinkStr := pieceLink.Link().String()
 
 		finder := mockPieceFinder{map[string]piece.PieceLink{digestStr: pieceLink}}
 		reader := mockPieceReader{map[string][]byte{pieceLinkStr: data}}


### PR DESCRIPTION
Ideally we remove this method from the interface too 